### PR TITLE
Added bait columns in "Timed Fish" tab

### DIFF
--- a/Gatherer.cs
+++ b/Gatherer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using Dalamud;
 using Dalamud.Plugin;
 using GatherBuddy.Classes;
@@ -410,6 +411,11 @@ namespace GatherBuddy
             {
                 PluginLog.Error($"Exception caught: {e}");
             }
+        }
+
+        public void OnFishActionWithBait(string baitName = "")
+        {
+            Clipboard.SetText(baitName);
         }
 
         public void OnFishActionWithFish(Fish? fish, string fishName = "")

--- a/Gui/Cache/FishTab.cs
+++ b/Gui/Cache/FishTab.cs
@@ -36,6 +36,7 @@ namespace GatherBuddy.Gui.Cache
         public readonly float LongestFish;
         public readonly float LongestSpot;
         public readonly float LongestZone;
+        public readonly float LongestBait;
         public readonly float LongestPercentage;
         public readonly float LongestMinutes;
 
@@ -109,6 +110,10 @@ namespace GatherBuddy.Gui.Cache
                 LongestFish       = Math.Max(LongestFish, ImGui.CalcTextSize(fish.Name).X / ImGui.GetIO().FontGlobalScale);
                 LongestSpot       = Math.Max(LongestSpot, ImGui.CalcTextSize(fish.FishingSpot).X / ImGui.GetIO().FontGlobalScale);
                 LongestZone       = Math.Max(LongestZone, ImGui.CalcTextSize(fish.Territory).X / ImGui.GetIO().FontGlobalScale);
+                if (fish.Bait.Count() > 0)
+                {
+                    LongestBait   = Math.Max(LongestBait, ImGui.CalcTextSize(fish.Bait[0].Name).X / ImGui.GetIO().FontGlobalScale);
+                }
                 LongestPercentage = Math.Max(LongestPercentage, ImGui.CalcTextSize(fish.UptimeString).X / ImGui.GetIO().FontGlobalScale);
             }
             LongestMinutes = ImGui.CalcTextSize("0000:00 Minutes").X / ImGui.GetIO().FontGlobalScale;

--- a/Gui/TabFish.cs
+++ b/Gui/TabFish.cs
@@ -9,7 +9,7 @@ namespace GatherBuddy.Gui
 {
     public partial class Interface
     {
-        private const int NumFishColumns = 6;
+        private const int NumFishColumns = 8;
 
         private static void PrintSeconds(long seconds)
         {
@@ -37,6 +37,26 @@ namespace GatherBuddy.Gui
                 _plugin.Gatherer!.OnFishActionWithFish(fish.Base);
             if (ImGui.IsItemHovered())
                 SetTooltip(fish);
+
+            ImGui.TableNextColumn();
+            if (fish.Bait.Count() > 0)
+            {
+                var baitIcon = fish.Bait[0].Icon;
+                ImGui.Image(baitIcon.ImGuiHandle, _fishIconSize);
+                if (ImGui.IsItemHovered())
+                {
+                    using var tt = ImGuiRaii.NewTooltip();
+                    ImGui.Image(baitIcon.ImGuiHandle, new Vector2(baitIcon.Width, baitIcon.Height));
+                }
+            }
+
+            ImGui.TableNextColumn();
+            if (fish.Bait.Count() > 0)
+            {
+                var baitName = fish.Bait[0].Name;
+                if (ImGui.Selectable(baitName))
+                    _plugin.Gatherer!.OnFishActionWithBait(baitName);
+            }
 
             var uptime = fish.Base.NextUptime(_plugin.Gatherer!.WeatherManager);
             ImGui.TableNextColumn();
@@ -182,6 +202,14 @@ namespace GatherBuddy.Gui
 
                 ImGui.TableHeader("Name");
                 ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthFixed, _fishCache.LongestFish * _globalScale);
+                ImGui.NextColumn();
+
+                ImGui.TableHeader("BaitIcon");
+                ImGui.TableSetupColumn("Bait", ImGuiTableColumnFlags.WidthFixed, ImGui.GetTextLineHeight());
+                ImGui.NextColumn();
+
+                ImGui.TableHeader("Bait");
+                ImGui.TableSetupColumn("Bait", ImGuiTableColumnFlags.WidthFixed, _fishCache.LongestBait * _globalScale);
                 ImGui.NextColumn();
 
                 ImGui.TableHeader("Wait / Uptime");


### PR DESCRIPTION
Changes:
* Added BaitIcon and BaitName column to "Timed Fish" tab
* Enabled clipboard pasting after clicking on BaitName column

To-do:
* Hover on BaitName column shows all NPCs that sells this bait
* Click on BaitName column will teleport player to nearest (cheapest) aetheryte and mark the NPC on map

![image](https://user-images.githubusercontent.com/6809863/120404716-d3261400-c2fb-11eb-99d4-9bcd18b219eb.png)


Relate to issue: #15 