### PR TITLE
Fix TugType

### DIFF
--- a/SeFunctions/SeTugType.cs
+++ b/SeFunctions/SeTugType.cs
@@ -10,7 +10,7 @@ namespace GatherBuddy.SeFunctions
         {
             get
             {
-                if (Address != IntPtr.Zero)
+                if (Address == IntPtr.Zero)
                     return BiteType.Unknown;
 
                 var tug = *(byte*) Address;


### PR DESCRIPTION
I noticed it was returning Unknown when the address is found instead of when the address is missing.

I'm trying to understand plugins and took yours as a learning experiment to see how it does things. Amazing work, btw, the reverse engineerig part is certainly not easy to grasp.
But about the actual change I'm proposing.. I'm not sure of the implications of it since it doesn't seem to be used. Maybe fishes can be highlighted in the UI according to this new info?