### PR TITLE
added /gatherf command

### DIFF
--- a/GatherBuddy/GatherBuddy.cs
+++ b/GatherBuddy/GatherBuddy.cs
@@ -58,8 +58,14 @@ namespace GatherBuddy
 
             Dalamud.Commands.AddHandler("/gather", new CommandInfo(OnGather)
             {
-                HelpMessage = "Mark the nearest node containing the item supplied, teleport to the nearest aetheryte, equip appropriate gear.",
+                HelpMessage = "Mark the nearest node containing the item supplied, teleport to the nearest aetheryte, equip appropriate gear. Does not execute for timed nodes that are unavailabe.",
                 ShowInHelp  = true,
+            });
+
+            Dalamud.Commands.AddHandler("/gatherf", new CommandInfo(OnGatherForce)
+            {
+                HelpMessage = "Mark the nearest node containing the item supplied, teleport to the nearest aetheryte, equip appropriate gear. Still executes for timed nodes that are unavailable.",
+                ShowInHelp = true,
             });
 
             Dalamud.Commands.AddHandler("/gatherbtn", new CommandInfo(OnGatherBtn)
@@ -116,6 +122,7 @@ namespace GatherBuddy
             (Gatherer as IDisposable).Dispose();
             Dalamud.Commands.RemoveHandler("/gatherdebug");
             Dalamud.Commands.RemoveHandler("/gather");
+            Dalamud.Commands.RemoveHandler("/gatherf");
             Dalamud.Commands.RemoveHandler("/gatherbtn");
             Dalamud.Commands.RemoveHandler("/gathermin");
             Dalamud.Commands.RemoveHandler("/gatherfish");
@@ -129,6 +136,14 @@ namespace GatherBuddy
                 Dalamud.Chat.Print("Please supply a (partial) item name for /gather.");
             else
                 Gatherer!.OnGatherAction(arguments);
+        }
+
+        private void OnGatherForce(string command, string arguments)
+        {
+            if (arguments.Length == 0)
+                Dalamud.Chat.Print("Please supply a (partial) item name for /gather.");
+            else
+                Gatherer!.OnGatherAction(arguments, null, true);
         }
 
         private void OnGatherBtn(string command, string arguments)

--- a/GatherBuddy/Gatherer.cs
+++ b/GatherBuddy/Gatherer.cs
@@ -144,7 +144,7 @@ namespace GatherBuddy
             return fish;
         }
 
-        private Node? GetClosestNode(string itemName, GatheringType? type = null)
+        private Node? GetClosestNode(string itemName, bool force, GatheringType? type = null)
         {
             var item = FindItemLogging(itemName);
             if (item == null)
@@ -185,9 +185,19 @@ namespace GatherBuddy
                 var diff    = nextUptime.Start.AddMilliseconds(-now);
                 var minutes = diff.CurrentMinuteOfDay;
                 var seconds = diff.CurrentSecond;
-                Dalamud.Chat.Print(minutes > 0
+                var logMessage = minutes > 0
                     ? $"Node is up at {closestNode!.Times!.PrintHours()} (in {minutes}:{seconds:D2} Minutes)."
-                    : $"Node is up at {closestNode!.Times!.PrintHours()} (in {seconds} Seconds).");
+                    : $"Node is up at {closestNode!.Times!.PrintHours()} (in {seconds} Seconds).";
+                if (force)
+                {
+                    Dalamud.Chat.Print(logMessage);
+                }
+                else
+                {
+                    logMessage += " If you would like to teleport and commence gathering anyways, use the /gatherf command.";
+                    Dalamud.Chat.Print(logMessage);
+                    return null;
+                }
             }
             else
             {
@@ -398,7 +408,7 @@ namespace GatherBuddy
             }
         }
 
-        public void OnGatherAction(string itemName, GatheringType? type = null)
+        public void OnGatherAction(string itemName, GatheringType? type = null, bool force = false)
         {
             try
             {
@@ -428,7 +438,7 @@ namespace GatherBuddy
                 }
                 else
                 {
-                    var closestNode = GetClosestNode(itemName, type);
+                    var closestNode = GetClosestNode(itemName, force, type);
                     if (closestNode == null)
                         return;
 


### PR DESCRIPTION
If the requested node is a timed node that's not up yet, then print the time when it's coming up and do nothing (don't teleport, don't switch classes, don't put a flag on the map). If you want to gather anyways, use the /gatherf command.

I felt like this could be a useful feature, as I sometimes use /gather as an easy way to see which nodes are coming up when without having to tab out of the game and search it up in a browser. It's extra useful because some of the timestamps don't show up in the gathering log if you haven't gathered the item before. I also don't see a point to teleporting all the way there only to have the node come up in half an hour.