### PR TITLE
Add a config option for FishTimerWindow clickthrough

### DIFF
--- a/GatherBuddy/Config/Configuration.cs
+++ b/GatherBuddy/Config/Configuration.cs
@@ -75,14 +75,15 @@ public partial class Configuration : IPluginConfiguration
     public int SeColorAlarm     = DefaultSeColorAlarm;
 
     // Fish Timer
-    public bool   ShowFishTimer        { get; set; } = true;
-    public bool   FishTimerEdit        { get; set; } = true;
-    public bool   HideUncaughtFish     { get; set; } = false;
-    public bool   HideUnavailableFish  { get; set; } = false;
-    public bool   ShowFishTimerUptimes { get; set; } = true;
-    public bool   HideFishSizePopup    { get; set; } = false;
-    public ushort FishTimerScale       { get; set; } = 40000;
-    public byte   ShowSecondIntervals  { get; set; } = 7;
+    public bool   ShowFishTimer         { get; set; } = true;
+    public bool   FishTimerEdit         { get; set; } = true;
+    public bool   FishTimerClickthrough { get; set; } = false;
+    public bool   HideUncaughtFish      { get; set; } = false;
+    public bool   HideUnavailableFish   { get; set; } = false;
+    public bool   ShowFishTimerUptimes  { get; set; } = true;
+    public bool   HideFishSizePopup     { get; set; } = false;
+    public ushort FishTimerScale        { get; set; } = 40000;
+    public byte   ShowSecondIntervals   { get; set; } = 7;
 
     // Spearfish Helper
     public bool ShowSpearfishHelper          { get; set; } = true;

--- a/GatherBuddy/FishTimer/FishTimerWindow.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.cs
@@ -21,7 +21,8 @@ public partial class FishTimerWindow : Window
       | ImGuiWindowFlags.NoDecoration
       | ImGuiWindowFlags.NoResize
       | ImGuiWindowFlags.NoMove
-      | ImGuiWindowFlags.NoNavFocus;
+      | ImGuiWindowFlags.NoNavFocus
+      | ImGuiWindowFlags.NoMouseInputs;
 
     private          FishingSpot? _spot;
     private          FishCache[]  _availableFish = Array.Empty<FishCache>();

--- a/GatherBuddy/FishTimer/FishTimerWindow.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.cs
@@ -21,8 +21,7 @@ public partial class FishTimerWindow : Window
       | ImGuiWindowFlags.NoDecoration
       | ImGuiWindowFlags.NoResize
       | ImGuiWindowFlags.NoMove
-      | ImGuiWindowFlags.NoNavFocus
-      | ImGuiWindowFlags.NoMouseInputs;
+      | ImGuiWindowFlags.NoNavFocus;
 
     private          FishingSpot? _spot;
     private          FishCache[]  _availableFish = Array.Empty<FishCache>();
@@ -195,6 +194,8 @@ public partial class FishTimerWindow : Window
             MaximumSize = new Vector2(2000, _maxListHeight / ImGuiHelpers.GlobalScale),
         };
         Flags = GatherBuddy.Config.FishTimerEdit ? EditFlags : NormalFlags;
+        if (!GatherBuddy.Config.FishTimerEdit && GatherBuddy.Config.FishTimerClickthrough)
+            Flags |= ImGuiWindowFlags.NoMouseInputs;
     }
 
     public override void PostDraw()

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -247,6 +247,11 @@ public partial class Interface
                 "Enable editing the fish timer window.",
                 GatherBuddy.Config.FishTimerEdit, b => GatherBuddy.Config.FishTimerEdit = b);
 
+        public static void DrawFishTimerClickthroughBox()
+            => DrawCheckbox("Enable fish timer window clickthrough",
+                "Allow clicking through the fish timer by disabling mouse events and context menus.",
+                GatherBuddy.Config.FishTimerClickthrough, b => GatherBuddy.Config.FishTimerClickthrough = b);
+
         public static void DrawFishTimerHideBox()
             => DrawCheckbox("Hide Uncaught Fish in Fish Timer",
                 "Hide all fish from the fish timer window that have not been recorded with the given combination of snagging and bait.",
@@ -575,6 +580,7 @@ public partial class Interface
                 ConfigFunctions.DrawKeepRecordsBox();
                 ConfigFunctions.DrawFishTimerBox();
                 ConfigFunctions.DrawFishTimerEditBox();
+                ConfigFunctions.DrawFishTimerClickthroughBox();
                 ConfigFunctions.DrawFishTimerHideBox();
                 ConfigFunctions.DrawFishTimerHideBox2();
                 ConfigFunctions.DrawFishTimerUptimesBox();


### PR DESCRIPTION
Add a config option to all clicks to be passed through.

If you don't use the context menus, not being able to click game ui underneath the fish timer is frustrating.