### PR TITLE
Add uptime for ocean fish

### DIFF
--- a/GatherBuddy.GameData/Classes/Fish.CatchData.cs
+++ b/GatherBuddy.GameData/Classes/Fish.CatchData.cs
@@ -22,6 +22,7 @@ public partial class Fish
     public SpearfishSpeed    Speed           { get; internal set; } = SpearfishSpeed.Unknown;
     public Fish?             SurfaceSlap     { get; internal set; } = null;
     public string            Guide           { get; internal set; } = string.Empty;
+    public OceanTime[]       OceanTimes      { get; internal set; } = System.Array.Empty<OceanTime>();
 
     internal OptionalBool BigFishOverride { get; set; } = null;
 }

--- a/GatherBuddy.GameData/Data/Fish/Data5.2.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data5.2.cs
@@ -167,22 +167,26 @@ public static partial class Fish
             .Bite      (HookSet.Powerful, BiteType.Strong);
         data.Apply     (29751, Patch.EchoesOfAFallenStar) // Quicksilver Blade
             .Bait      (data, 29716)
-            .Bite      (HookSet.Powerful, BiteType.Strong);
+            .Bite      (HookSet.Powerful, BiteType.Strong)
+            .OceanTimes(OceanTime.Sunset);
         data.Apply     (29752, Patch.EchoesOfAFallenStar) // Navigator's Print
             .Bait      (data, 29715)
             .Bite      (HookSet.Precise, BiteType.Weak);
         data.Apply     (29753, Patch.EchoesOfAFallenStar) // Casket Oyster
             .Bait      (data, 29714)
-            .Bite      (HookSet.Precise, BiteType.Weak);
+            .Bite      (HookSet.Precise, BiteType.Weak)
+            .OceanTimes(OceanTime.Day);
         data.Apply     (29754, Patch.EchoesOfAFallenStar) // Fishmonger
             .Bait      (data, 29716)
             .Bite      (HookSet.Powerful, BiteType.Strong);
         data.Apply     (29755, Patch.EchoesOfAFallenStar) // Mythril Sovereign
             .Bait      (data, 29715)
-            .Bite      (HookSet.Powerful, BiteType.Strong);
+            .Bite      (HookSet.Powerful, BiteType.Strong)
+            .OceanTimes(OceanTime.Day);
         data.Apply     (29756, Patch.EchoesOfAFallenStar) // Nimble Dancer
             .Bait      (data, 29714)
-            .Bite      (HookSet.Precise, BiteType.Weak);
+            .Bite      (HookSet.Precise, BiteType.Weak)
+            .OceanTimes(OceanTime.Day);
         data.Apply     (29757, Patch.EchoesOfAFallenStar) // Sea Nettle
             .Bait      (data, 29714)
             .Bite      (HookSet.Precise, BiteType.Weak);
@@ -200,22 +204,27 @@ public static partial class Fish
             .Bite      (HookSet.Precise, BiteType.Weak);
         data.Apply     (29762, Patch.EchoesOfAFallenStar) // Floating Saucer
             .Bait      (data, 29715)
-            .Bite      (HookSet.Precise, BiteType.Weak);
+            .Bite      (HookSet.Precise, BiteType.Weak)
+            .OceanTimes(OceanTime.Night);
         data.Apply     (29763, Patch.EchoesOfAFallenStar) // Aetheric Seadragon
             .Bait      (data, 29714, 29761)
-            .Bite      (HookSet.Powerful, BiteType.Strong);
+            .Bite      (HookSet.Powerful, BiteType.Strong)
+            .OceanTimes(OceanTime.Night);
         data.Apply     (29764, Patch.EchoesOfAFallenStar) // Coral Seadragon
             .Bait      (data, 29714)
-            .Bite      (HookSet.Precise, BiteType.Weak);
+            .Bite      (HookSet.Precise, BiteType.Weak)
+            .OceanTimes(OceanTime.Sunset);
         data.Apply     (29765, Patch.EchoesOfAFallenStar) // Roguesaurus
             .Bait      (data, 29714, 29761)
-            .Bite      (HookSet.Powerful, BiteType.Legendary);
+            .Bite      (HookSet.Powerful, BiteType.Legendary)
+            .OceanTimes(OceanTime.Sunset);
         data.Apply     (29766, Patch.EchoesOfAFallenStar) // Merman's Mane
             .Bait      (data, 29715)
             .Bite      (HookSet.Powerful, BiteType.Strong);
         data.Apply     (29767, Patch.EchoesOfAFallenStar) // Sweeper
             .Bait      (data, 29716)
-            .Bite      (HookSet.Powerful, BiteType.Strong);
+            .Bite      (HookSet.Powerful, BiteType.Strong)
+            .OceanTimes(OceanTime.Day);
         data.Apply     (29768, Patch.EchoesOfAFallenStar) // Silencer
             .Bait      (data, 29714)
             .Bite      (HookSet.Precise, BiteType.Weak);
@@ -224,7 +233,8 @@ public static partial class Fish
             .Bite      (HookSet.Powerful, BiteType.Strong);
         data.Apply     (29770, Patch.EchoesOfAFallenStar) // Executioner
             .Bait      (data, 29716)
-            .Bite      (HookSet.Powerful, BiteType.Legendary);
+            .Bite      (HookSet.Powerful, BiteType.Legendary)
+            .OceanTimes(OceanTime.Day);
         data.Apply     (29771, Patch.EchoesOfAFallenStar) // Wild Urchin
             .Bait      (data, 29714)
             .Bite      (HookSet.Precise, BiteType.Weak);
@@ -233,10 +243,12 @@ public static partial class Fish
             .Bite      (HookSet.Powerful, BiteType.Strong);
         data.Apply     (29773, Patch.EchoesOfAFallenStar) // Mopbeard
             .Bait      (data, 29715)
-            .Bite      (HookSet.Powerful, BiteType.Strong);
+            .Bite      (HookSet.Powerful, BiteType.Strong)
+            .OceanTimes(OceanTime.Night);
         data.Apply     (29774, Patch.EchoesOfAFallenStar) // Slipsnail
             .Bait      (data, 29714)
-            .Bite      (HookSet.Precise, BiteType.Weak);
+            .Bite      (HookSet.Precise, BiteType.Weak)
+            .OceanTimes(OceanTime.Night);
         data.Apply     (29775, Patch.EchoesOfAFallenStar) // Aronnax
             .Bait      (data, 29715)
             .Bite      (HookSet.Precise, BiteType.Weak);
@@ -245,7 +257,8 @@ public static partial class Fish
             .Bite      (HookSet.Powerful, BiteType.Strong);
         data.Apply     (29777, Patch.EchoesOfAFallenStar) // Bartholomew the Chopper
             .Bait      (data, 29714)
-            .Bite      (HookSet.Precise, BiteType.Weak);
+            .Bite      (HookSet.Precise, BiteType.Weak)
+            .OceanTimes(OceanTime.Night);
         data.Apply     (29778, Patch.EchoesOfAFallenStar) // Prowler
             .Bait      (data, 29714)
             .Bite      (HookSet.Precise, BiteType.Weak);
@@ -260,10 +273,12 @@ public static partial class Fish
             .Bite      (HookSet.Powerful, BiteType.Legendary);
         data.Apply     (29782, Patch.EchoesOfAFallenStar) // Funnel Shark
             .Bait      (data, 29716)
-            .Bite      (HookSet.Powerful, BiteType.Legendary);
+            .Bite      (HookSet.Powerful, BiteType.Legendary)
+            .OceanTimes(OceanTime.Sunset);
         data.Apply     (29783, Patch.EchoesOfAFallenStar) // The Fallen One
             .Bait      (data, 29715)
-            .Bite      (HookSet.Powerful, BiteType.Strong);
+            .Bite      (HookSet.Powerful, BiteType.Strong)
+            .OceanTimes(OceanTime.Sunset);
         data.Apply     (29784, Patch.EchoesOfAFallenStar) // Spectral Megalodon
             .Bait      (data, 29716)
             .Bite      (HookSet.Powerful, BiteType.Legendary);
@@ -279,18 +294,22 @@ public static partial class Fish
         data.Apply     (29788, Patch.EchoesOfAFallenStar) // Sothis
             .Bait      (data, 2603)
             .Bite      (HookSet.Powerful, BiteType.Legendary)
+            .OceanTimes(OceanTime.Night)
             .Predators (data, 15, (29749, 2), (29752, 1));
         data.Apply     (29789, Patch.EchoesOfAFallenStar) // Coral Manta
             .Bait      (data, 2613)
             .Bite      (HookSet.Powerful, BiteType.Legendary)
+            .OceanTimes(OceanTime.Night)
             .Predators (data, 15, (29758, 2));
         data.Apply     (29790, Patch.EchoesOfAFallenStar) // Stonescale
             .Bait      (data, 2591)
             .Bite      (HookSet.Powerful, BiteType.Legendary)
+            .OceanTimes(OceanTime.Sunset)
             .Predators (data, 15, (29769, 1), (29768, 1));
         data.Apply     (29791, Patch.EchoesOfAFallenStar) // Elasmosaurus
             .Bait      (data, 2619)
             .Bite      (HookSet.Powerful, BiteType.Legendary)
+            .OceanTimes(OceanTime.Day)
             .Predators (data, 15, (29781, 3));
         data.Apply     (29994, Patch.EchoesOfAFallenStar) // Grade 2 Skybuilders' Cloudskipper
             .Bait      (data);

--- a/GatherBuddy.GameData/Data/Fish/Data5.2.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data5.2.cs
@@ -189,7 +189,8 @@ public static partial class Fish
             .OceanTimes(OceanTime.Day);
         data.Apply     (29757, Patch.EchoesOfAFallenStar) // Sea Nettle
             .Bait      (data, 29714)
-            .Bite      (HookSet.Precise, BiteType.Weak);
+            .Bite      (HookSet.Precise, BiteType.Weak)
+            .OceanTimes(OceanTime.Sunset);
         data.Apply     (29758, Patch.EchoesOfAFallenStar) // Great Grandmarlin
             .Bait      (data, 29714, 29761)
             .Bite      (HookSet.Powerful, BiteType.Strong);

--- a/GatherBuddy.GameData/Data/Fish/Data5.4.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data5.4.cs
@@ -93,22 +93,27 @@ public static partial class Fish
             .Bite      (HookSet.Precise, BiteType.Weak);
         data.Apply     (32069, Patch.FuturesRewritten) // Flaming Eel
             .Bait      (data, 29715)
-            .Bite      (HookSet.Powerful, BiteType.Strong);
+            .Bite      (HookSet.Powerful, BiteType.Strong)
+            .OceanTimes(OceanTime.Sunset);
         data.Apply     (32070, Patch.FuturesRewritten) // Jetborne Manta
             .Bait      (data, 29716)
             .Bite      (HookSet.Powerful, BiteType.Legendary);
         data.Apply     (32071, Patch.FuturesRewritten) // Devil's Sting
             .Bait      (data, 29715)
-            .Bite      (HookSet.Powerful, BiteType.Strong);
+            .Bite      (HookSet.Powerful, BiteType.Strong)
+            .OceanTimes(OceanTime.Day);
         data.Apply     (32072, Patch.FuturesRewritten) // Callichthyid
             .Bait      (data, 29716)
-            .Bite      (HookSet.Powerful, BiteType.Legendary);
+            .Bite      (HookSet.Powerful, BiteType.Legendary)
+            .OceanTimes(OceanTime.Day);
         data.Apply     (32073, Patch.FuturesRewritten) // Meandering Mora
             .Bait      (data, 29716)
-            .Bite      (HookSet.Powerful, BiteType.Strong);
+            .Bite      (HookSet.Powerful, BiteType.Strong)
+            .OceanTimes(OceanTime.Sunset);
         data.Apply     (32074, Patch.FuturesRewritten) // Hafgufa
             .Bait      (data, 27590)
             .Bite      (HookSet.Powerful, BiteType.Legendary)
+            .OceanTimes(OceanTime.Night)
             .Predators (data, 15, (32070, 2), (32067, 1));
         data.Apply     (32075, Patch.FuturesRewritten) // Thaliak Crab
             .Bait      (data, 29714)
@@ -143,13 +148,15 @@ public static partial class Fish
             .Predators (data, 60, (32082, 1));
         data.Apply     (32085, Patch.FuturesRewritten) // Oracular Crab
             .Bait      (data, 29714)
-            .Bite      (HookSet.Precise, BiteType.Weak);
+            .Bite      (HookSet.Precise, BiteType.Weak)
+            .OceanTimes(OceanTime.Day);
         data.Apply     (32086, Patch.FuturesRewritten) // Dravanian Bream
             .Bait      (data, 29715)
             .Bite      (HookSet.Precise, BiteType.Weak);
         data.Apply     (32087, Patch.FuturesRewritten) // Skaldminni
             .Bait      (data, 29715)
-            .Bite      (HookSet.Powerful, BiteType.Strong);
+            .Bite      (HookSet.Powerful, BiteType.Strong)
+            .OceanTimes(OceanTime.Night);
         data.Apply     (32088, Patch.FuturesRewritten) // Serrated Clam
             .Bait      (data, 29714)
             .Bite      (HookSet.Precise, BiteType.Weak);
@@ -158,7 +165,8 @@ public static partial class Fish
             .Bite      (HookSet.Powerful, BiteType.Strong);
         data.Apply     (32090, Patch.FuturesRewritten) // Exterminator
             .Bait      (data, 29714)
-            .Bite      (HookSet.Precise, BiteType.Weak);
+            .Bite      (HookSet.Precise, BiteType.Weak)
+            .OceanTimes(OceanTime.Day);
         data.Apply     (32091, Patch.FuturesRewritten) // Gory Tuna
             .Bait      (data, 29716)
             .Bite      (HookSet.Powerful, BiteType.Strong);
@@ -171,6 +179,7 @@ public static partial class Fish
         data.Apply     (32094, Patch.FuturesRewritten) // Seafaring Toad
             .Bait      (data, 2587)
             .Bite      (HookSet.Precise, BiteType.Legendary)
+            .OceanTimes(OceanTime.Day)
             .Predators (data, 15, (32089, 3));
         data.Apply     (32095, Patch.FuturesRewritten) // Crow Puffer
             .Bait      (data, 29714)
@@ -205,7 +214,8 @@ public static partial class Fish
             .Predators (data, 60, (32096, 3));
         data.Apply     (32105, Patch.FuturesRewritten) // Garum Jug
             .Bait      (data, 29715)
-            .Bite      (HookSet.Precise, BiteType.Weak);
+            .Bite      (HookSet.Precise, BiteType.Weak)
+            .OceanTimes(OceanTime.Day, OceanTime.Night);
         data.Apply     (32106, Patch.FuturesRewritten) // Smooth Jaguar
             .Bait      (data, 29716)
             .Bite      (HookSet.Powerful, BiteType.Strong);
@@ -217,13 +227,15 @@ public static partial class Fish
             .Bite      (HookSet.Powerful, BiteType.Strong);
         data.Apply     (32109, Patch.FuturesRewritten) // Pearl Bombfish
             .Bait      (data, 29715)
-            .Bite      (HookSet.Powerful, BiteType.Strong);
+            .Bite      (HookSet.Powerful, BiteType.Strong)
+            .OceanTimes(OceanTime.Day, OceanTime.Night);
         data.Apply     (32110, Patch.FuturesRewritten) // Trollfish
             .Bait      (data, 29714, 32107)
             .Bite      (HookSet.Precise, BiteType.Weak);
         data.Apply     (32111, Patch.FuturesRewritten) // Panoptes
             .Bait      (data, 29716)
-            .Bite      (HookSet.Powerful, BiteType.Strong);
+            .Bite      (HookSet.Powerful, BiteType.Strong)
+            .OceanTimes(OceanTime.Day);
         data.Apply     (32112, Patch.FuturesRewritten) // Crepe Sole
             .Bait      (data, 29714)
             .Bite      (HookSet.Precise, BiteType.Weak);
@@ -233,6 +245,7 @@ public static partial class Fish
         data.Apply     (32114, Patch.FuturesRewritten) // Placodus
             .Bait      (data, 29714, 32107)
             .Bite      (HookSet.Powerful, BiteType.Legendary)
+            .OceanTimes(OceanTime.Sunset)
             .Predators (data, 45, (32110, 1));
         data.Apply     (32882, Patch.FuturesRewritten) // Grade 4 Skybuilders' Zagas Khaal
             .Bait      (data);

--- a/GatherBuddy.GameData/Data/Fish/DataBase.cs
+++ b/GatherBuddy.GameData/Data/Fish/DataBase.cs
@@ -201,6 +201,15 @@ public static partial class Fish
         return fish;
     }
 
+    private static Classes.Fish? OceanTimes(this Classes.Fish? fish, params OceanTime[] times)
+    {
+        if (fish == null)
+            return null;
+
+        fish.OceanTimes = times;
+        return fish;
+    }
+
     internal static void Apply(GameData data)
     {
         data.ApplyARealmReborn();

--- a/GatherBuddy.GameData/Enums/OceanTime.cs
+++ b/GatherBuddy.GameData/Enums/OceanTime.cs
@@ -1,0 +1,9 @@
+namespace GatherBuddy.Enums;
+
+// Ordered by the progression of time throughout a fishing route.
+public enum OceanTime
+{
+    Sunset,
+    Night,
+    Day,
+}

--- a/GatherBuddy.GameData/GameData.cs
+++ b/GatherBuddy.GameData/GameData.cs
@@ -152,7 +152,8 @@ public class GameData
 
             foreach (var fish in Fishes.Values)
             {
-                if (fish.FishingSpots.Count > 0 && fish.FishRestrictions != FishRestrictions.None && !fish.OceanFish)
+                var isRestrictedOceanFish = fish.OceanFish && fish.OceanTimes.Length > 0;
+                if (fish.FishingSpots.Count > 0 && fish.FishRestrictions != FishRestrictions.None || isRestrictedOceanFish)
                     fish.InternalLocationId = ++TimedGatherables;
                 else if (fish.FishingSpots.Count > 0)
                     fish.InternalLocationId = -++MultiNodeGatherables;

--- a/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
@@ -101,27 +101,19 @@ public partial class FishTimerWindow
             NextUptime = TimeInterval.Always;
             _textLine   = fish.Name[GatherBuddy.Language];
 
-            // Ocean fish should not respect uptimes due to mechanics.
-            if (fish.OceanFish)
-            {
-                _color = FromData(fish.BiteType, fish.HookSet, Uncaught, false);
-            }
-            else
-            {
-                var uptime = GatherBuddy.UptimeManager.NextUptime(fish, spot.Territory, GatherBuddy.Time.ServerTime);
-                if (GatherBuddy.Config.ShowFishTimerUptimes && uptime != TimeInterval.Invalid && uptime != TimeInterval.Never)
-                    NextUptime = uptime;
-                if (GatherBuddy.Time.ServerTime < uptime.Start
-                 && (!flags.HasFlag(FishRecord.Effects.FishEyes) || fish.IsBigFish || fish.FishRestrictions.HasFlag(FishRestrictions.Weather)))
-                    Unavailable = true;
-                if (fish.Snagging == Snagging.Required && !flags.HasFlag(FishRecord.Effects.Snagging))
-                    Unavailable = true;
-                // Unavailable fish should be last.
-                if (Unavailable)
-                    SortOrder = ulong.MaxValue;
+            var uptime = GatherBuddy.UptimeManager.NextUptime(fish, spot.Territory, GatherBuddy.Time.ServerTime);
+            if (GatherBuddy.Config.ShowFishTimerUptimes && uptime != TimeInterval.Invalid && uptime != TimeInterval.Never)
+                NextUptime = uptime;
+            if (GatherBuddy.Time.ServerTime < uptime.Start
+              && (!flags.HasFlag(FishRecord.Effects.FishEyes) || fish.IsBigFish || fish.FishRestrictions.HasFlag(FishRestrictions.Weather)))
+                Unavailable = true;
+            if (fish.Snagging == Snagging.Required && !flags.HasFlag(FishRecord.Effects.Snagging))
+                Unavailable = true;
+            // Unavailable fish should be last.
+            if (Unavailable)
+                SortOrder = ulong.MaxValue;
 
-                _color = FromData(fish.BiteType, fish.HookSet, Uncaught, Unavailable);
-            }
+            _color = FromData(fish.BiteType, fish.HookSet, Uncaught, Unavailable);
         }
 
         private void DrawMarkers(ImDrawListPtr ptr, Vector2 pos, float height, float size)

--- a/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
@@ -104,8 +104,10 @@ public partial class FishTimerWindow
             var uptime = GatherBuddy.UptimeManager.NextUptime(fish, spot.Territory, GatherBuddy.Time.ServerTime);
             if (GatherBuddy.Config.ShowFishTimerUptimes && uptime != TimeInterval.Invalid && uptime != TimeInterval.Never)
                 NextUptime = uptime;
+            // Some non-spectral ocean fish have weather restrictions, but this is not handled.
+            var hasWeatherRestriction = fish.FishRestrictions.HasFlag(FishRestrictions.Weather) && !fish.OceanFish;
             if (GatherBuddy.Time.ServerTime < uptime.Start
-              && (!flags.HasFlag(FishRecord.Effects.FishEyes) || fish.IsBigFish || fish.FishRestrictions.HasFlag(FishRestrictions.Weather)))
+              && (!flags.HasFlag(FishRecord.Effects.FishEyes) || fish.IsBigFish || hasWeatherRestriction))
                 Unavailable = true;
             if (fish.Snagging == Snagging.Required && !flags.HasFlag(FishRecord.Effects.Snagging))
                 Unavailable = true;

--- a/GatherBuddy/Plugin/OceanUptime.cs
+++ b/GatherBuddy/Plugin/OceanUptime.cs
@@ -180,11 +180,11 @@ public static class OceanUptime
         if (!fish.OceanFish || fish.OceanTimes.Length == 0)
             return TimeInterval.Always;
 
-        // The offset in seconds from when the current loop started to the current time.
+        // The offset in milliseconds from when the current loop started to the current time.
         long loopOffsetMilliseconds = (utcNow.Time - LoopTimestampEpoch) % LoopDurationMilliseconds;
-        // The index into RouteLoop for the current timestamp.
+        // The index into RouteLoop for the given timestamp.
         var loopIdx = loopOffsetMilliseconds / TwoHoursInMilliseconds;
-        // The timestamp that this loop started.
+        // The timestamp that this loop started at.
         long loopStartTimestamp = utcNow.Time - loopOffsetMilliseconds;
 
         var spotIds = fish.FishingSpots.Select(spot => spot.Id);

--- a/GatherBuddy/Plugin/OceanUptime.cs
+++ b/GatherBuddy/Plugin/OceanUptime.cs
@@ -1,0 +1,224 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using GatherBuddy.Time;
+using System;
+using GatherBuddy.Classes;
+using System.Linq;
+using GatherBuddy.Enums;
+
+namespace GatherBuddy.Plugin;
+
+// A helper class for UptimeManager to deal with ocean fish uptime.
+public static class OceanUptime
+{
+    private enum OceanRoute
+    {
+        BloodbrineSea,
+        RothlytSound,
+        NorthernStraitofMerlthor,
+        RhotanoSea,
+    }
+
+    // A named enum with FishingSpot.Id values for convenience.
+    private enum OceanStop
+    {
+        TheCieldalaes = 246,
+        TheNorthernStraitOfMerlthor = 243,
+        TheBloodbrineSea = 248,
+        RhotanoSea = 241,
+        TheRothlytSound = 250,
+        TheSouthernStraitOfMerlthor = 239,
+        GaladionBay = 237,
+
+        TheCieldalaesSpectralCurrent = 247,
+        TheNorthernStraitOfMerlthorSpectralCurrent = 244,
+        TheBloodbrineSeaSpectralCurrent = 249,
+        RhotanoSeaSpectralCurrent = 242,
+        TheRothlytSoundSpectralCurrent = 251,
+        TheSouthernStraitOfMerlthorSpectralCurrent = 240,
+        GaladionBaySpectralCurrent = 238,
+    }
+
+    // The sopts are ordered the same way they are in game.
+    // If this is Bloodbrine Day, then the progression is Cieldales Sunset, Northern Strait Night, Bloodbrine Day.
+    private static readonly Dictionary<OceanRoute, OceanStop[]> RouteToStops = new Dictionary<OceanRoute, OceanStop[]>()
+    {
+        {
+            OceanRoute.BloodbrineSea,
+            new OceanStop[6]
+            {
+                OceanStop.TheCieldalaes,
+                OceanStop.TheCieldalaesSpectralCurrent,
+                OceanStop.TheNorthernStraitOfMerlthor,
+                OceanStop.TheNorthernStraitOfMerlthorSpectralCurrent,
+                OceanStop.TheBloodbrineSea,
+                OceanStop.TheBloodbrineSeaSpectralCurrent,
+            }
+        },
+        {
+            OceanRoute.RothlytSound,
+            new OceanStop[6]
+            {
+                OceanStop.TheCieldalaes,
+                OceanStop.TheCieldalaesSpectralCurrent,
+                OceanStop.RhotanoSea,
+                OceanStop.RhotanoSeaSpectralCurrent,
+                OceanStop.TheRothlytSound,
+                OceanStop.TheRothlytSoundSpectralCurrent,
+            }
+        },
+        {
+            OceanRoute.NorthernStraitofMerlthor,
+            new OceanStop[6]
+            {
+                OceanStop.TheSouthernStraitOfMerlthor,
+                OceanStop.TheSouthernStraitOfMerlthorSpectralCurrent,
+                OceanStop.GaladionBay,
+                OceanStop.GaladionBaySpectralCurrent,
+                OceanStop.TheNorthernStraitOfMerlthor,
+                OceanStop.TheNorthernStraitOfMerlthorSpectralCurrent,
+            }
+        },
+        {
+            OceanRoute.RhotanoSea,
+            new OceanStop[6]
+            {
+                OceanStop.GaladionBay,
+                OceanStop.GaladionBaySpectralCurrent,
+                OceanStop.TheSouthernStraitOfMerlthor,
+                OceanStop.TheSouthernStraitOfMerlthorSpectralCurrent,
+                OceanStop.RhotanoSea,
+                OceanStop.RhotanoSeaSpectralCurrent,
+            }
+        },
+    };
+
+    // Convenience function to return the subsequence OceanTime.
+    private static OceanTime NextTime(OceanTime time) {
+        return (OceanTime)(((int)time + 1) % 3);
+    }
+
+    private class TimedRoute
+    {
+        public OceanRoute Route;
+        public OceanTime Time;
+
+        public Dictionary<OceanTime, OceanStop[]> StopsByTime = new Dictionary<OceanTime, OceanStop[]>();
+
+        public TimedRoute(OceanRoute route, OceanTime time)
+        {
+            Route = route;
+            Time = time;
+
+            var stops = RouteToStops[route];
+
+            // Map all of the stops on the route by time for lookup later.
+            var firstTime = NextTime(time);
+            StopsByTime[firstTime] = new OceanStop[] { stops[0], stops[1] };
+            var secondTime = NextTime(firstTime);
+            StopsByTime[secondTime] = new OceanStop[] { stops[2], stops[3] };
+            var thirdTime = NextTime(secondTime);
+            StopsByTime[thirdTime] = new OceanStop[] { stops[4], stops[5] };
+        }
+    }
+
+    // The loop of 144 TimedRoutes.
+    private static readonly TimedRoute[] RouteLoop;
+
+    // The full loop of 144 timed routes at 2 hours each takes 12 days, beginning at this timestamp.
+    private static long LoopTimestampEpoch = 748800000;
+    private static long LoopDurationMilliseconds = 12 * 24 * 60 * 60 * 1000;
+    private static long OneHourInMilliseconds = 60 * 60 * 1000;
+    private static long TwoHoursInMilliseconds = 2 * OneHourInMilliseconds;
+
+    private static TimedRoute[] BuildRouteLoop()
+    {
+        var fixedRouteOrder = new TimedRoute[12]
+        {
+            new TimedRoute(OceanRoute.BloodbrineSea, OceanTime.Sunset),
+            new TimedRoute(OceanRoute.RothlytSound, OceanTime.Sunset),
+            new TimedRoute(OceanRoute.NorthernStraitofMerlthor, OceanTime.Sunset),
+            new TimedRoute(OceanRoute.RhotanoSea, OceanTime.Sunset),
+
+            new TimedRoute(OceanRoute.BloodbrineSea, OceanTime.Night),
+            new TimedRoute(OceanRoute.RothlytSound, OceanTime.Night),
+            new TimedRoute(OceanRoute.NorthernStraitofMerlthor, OceanTime.Night),
+            new TimedRoute(OceanRoute.RhotanoSea, OceanTime.Night),
+
+            new TimedRoute(OceanRoute.BloodbrineSea, OceanTime.Day),
+            new TimedRoute(OceanRoute.RothlytSound, OceanTime.Day),
+            new TimedRoute(OceanRoute.NorthernStraitofMerlthor, OceanTime.Day),
+            new TimedRoute(OceanRoute.RhotanoSea, OceanTime.Day),
+        };
+
+        var loop = new TimedRoute[144];
+
+        int outputIdx = 0;
+
+        // The full fixed route first (-1), and then the fixed route
+        // but removing one item (in order) each time, for a total of
+        // 12 + 11 * 12 = 144 items in the loop.
+        for (int skipIdx = -1; skipIdx < fixedRouteOrder.Length; skipIdx++)
+        {
+            for (int routeIdx = 0; routeIdx < fixedRouteOrder.Length; routeIdx++)
+            {
+                if (routeIdx == skipIdx)
+                    continue;
+                loop[outputIdx] = fixedRouteOrder[routeIdx];
+                outputIdx++;
+            }
+        }
+
+        Debug.Assert(outputIdx == 144);
+        return loop;
+    }
+
+
+    // Returns the current/next TimeInterval from a utc timestamp for this ocean fish.
+    public static TimeInterval GetOceanUptime(Fish fish, TimeStamp utcNow)
+    {
+        if (!fish.OceanFish || fish.OceanTimes.Length == 0)
+            return TimeInterval.Always;
+
+        // The offset in seconds from when the current loop started to the current time.
+        long loopOffsetMilliseconds = (utcNow.Time - LoopTimestampEpoch) % LoopDurationMilliseconds;
+        // The index into RouteLoop for the current timestamp.
+        var loopIdx = loopOffsetMilliseconds / TwoHoursInMilliseconds;
+        // The timestamp that this loop started.
+        long loopStartTimestamp = utcNow.Time - loopOffsetMilliseconds;
+
+        var spotIds = fish.FishingSpots.Select(spot => spot.Id);
+
+        // Every stop/time combination exists in at least two adjacent fixed routes (since it might
+        // be skipped in one of the routes, but can't be skipped twice), so this will need to check
+        // ~22 routes at most.
+        for (int loopCount = 0; loopCount < 25; loopCount++)
+        {
+            var timedRoute = RouteLoop[loopIdx % RouteLoop.Length];
+            foreach (var time in fish.OceanTimes)
+            {
+                if (!Array.Exists(timedRoute.StopsByTime[time], spotId => spotIds.Contains((uint)spotId)))
+                    continue;
+
+                // Arbitrarily say that the window is an hour long rather than two.
+                // Boats can queue up to 15 minutes past the hour, and boats are roughly 25 minutes.
+                // There can be delay for cutscenes/players loading as well.  An hour is safe.
+                var start = loopStartTimestamp + loopIdx * TwoHoursInMilliseconds;
+                var end = start + OneHourInMilliseconds;
+                if (end < utcNow)
+                    continue;
+                return new TimeInterval(new TimeStamp(start), new TimeStamp(end));
+            }
+
+            loopIdx++;
+        }
+
+        // The lookup above shouldn't fail unless data is wrong or something is awry.
+        return TimeInterval.Always;
+    }
+
+    static OceanUptime()
+    {
+        RouteLoop = BuildRouteLoop();
+    }
+}

--- a/GatherBuddy/Plugin/OceanUptime.cs
+++ b/GatherBuddy/Plugin/OceanUptime.cs
@@ -39,7 +39,7 @@ public static class OceanUptime
         GaladionBaySpectralCurrent = 238,
     }
 
-    // The sopts are ordered the same way they are in game.
+    // The spots are ordered the same way they are in game.
     // If this is Bloodbrine Day, then the progression is Cieldales Sunset, Northern Strait Night, Bloodbrine Day.
     private static readonly Dictionary<OceanRoute, OceanStop[]> RouteToStops = new Dictionary<OceanRoute, OceanStop[]>()
     {
@@ -93,7 +93,7 @@ public static class OceanUptime
         },
     };
 
-    // Convenience function to return the subsequence OceanTime.
+    // Convenience function to return the subsequent OceanTime.
     private static OceanTime NextTime(OceanTime time) {
         return (OceanTime)(((int)time + 1) % 3);
     }

--- a/GatherBuddy/Plugin/UptimeManager.cs
+++ b/GatherBuddy/Plugin/UptimeManager.cs
@@ -108,6 +108,15 @@ public class UptimeManager : IDisposable
     // Obtain the next uptime for a fish from now in a specific territory.
     private static TimeInterval GetUptime(Fish fish, Territory territory, TimeStamp now)
     {
+        if (fish.OceanFish)
+        {
+            if (fish.OceanTimes.Length == 0)
+                return TimeInterval.Always;
+
+            // Ocean fish timing is based on the real world time determine routes, not server time.
+            return OceanUptime.GetOceanUptime(fish, TimeStamp.UtcNow);
+        }
+
         if (fish.FishRestrictions == FishRestrictions.Time)
             return fish.Interval == RepeatingInterval.Always ? TimeInterval.Invalid : fish.Interval.NextRealUptime(now);
 

--- a/GatherBuddy/Plugin/UptimeManager.cs
+++ b/GatherBuddy/Plugin/UptimeManager.cs
@@ -110,10 +110,7 @@ public class UptimeManager : IDisposable
     {
         if (fish.OceanFish)
         {
-            if (fish.OceanTimes.Length == 0)
-                return TimeInterval.Always;
-
-            // Ocean fish timing is based on the real world time determine routes, not server time.
+            // Ocean fish timing is based on the real world time, not server time.
             return OceanUptime.GetOceanUptime(fish, TimeStamp.UtcNow);
         }
 

--- a/GatherBuddy/Plugin/UptimeManager.cs
+++ b/GatherBuddy/Plugin/UptimeManager.cs
@@ -209,10 +209,20 @@ public class UptimeManager : IDisposable
         if (fish.InternalLocationId <= 0)
             return TimeInterval.Always;
 
-        // Unknown
-        if (fish.FishRestrictions.HasFlag(FishRestrictions.Time) && fish.Interval.AlwaysUp()
-         || fish.FishRestrictions.HasFlag(FishRestrictions.Weather) && fish.PreviousWeather.Length == 0 && fish.CurrentWeather.Length == 0)
-            return TimeInterval.Invalid;
+
+        // Some spectral ocean fish have time restrictions (handled specially in GetUptime)
+        // and some non-spectral ocean fish have weather restrictions (not handled).
+        // Skip all of them here, as they should be considered AlwaysUp instead of Invalid.
+        if (!fish.OceanFish)
+        {
+            // Invalid
+            if (fish.FishRestrictions.HasFlag(FishRestrictions.Time) && fish.Interval.AlwaysUp())
+                return TimeInterval.Invalid;
+
+            // Unknown
+            if (fish.FishRestrictions.HasFlag(FishRestrictions.Weather) && fish.PreviousWeather.Length == 0 && fish.CurrentWeather.Length == 0)
+                return TimeInterval.Invalid;
+        }
 
         return GetUptime(fish, territory, now);
     }


### PR DESCRIPTION
Adds ocean fishing time (sunset, night, day) to individual fish, and route calculation based on real time to figure out when those routes are available.