### PR TITLE
Play alarm sound on change

### DIFF
--- a/GatherBuddy/Alarms/AlarmManager.cs
+++ b/GatherBuddy/Alarms/AlarmManager.cs
@@ -70,6 +70,9 @@ public partial class AlarmManager : IDisposable
     private void TriggerHourAlarm()
         => _sounds.Play(GatherBuddy.Config.HourAlarm);
 
+    public void PreviewAlarm(Sounds id)
+        => _sounds.Play(id);
+
 
     public void AddActiveAlarm(Alarm alarm, bool trigger = true)
     {

--- a/GatherBuddy/Gui/Interface.AlarmTab.cs
+++ b/GatherBuddy/Gui/Interface.AlarmTab.cs
@@ -8,10 +8,12 @@ using GatherBuddy.Config;
 using GatherBuddy.GatherHelper;
 using GatherBuddy.Interfaces;
 using GatherBuddy.Plugin;
+using GatherBuddy.SeFunctions;
 using GatherBuddy.Time;
 using ImGuiNET;
 using OtterGui;
 using OtterGui.Widgets;
+using static Lumina.Data.Files.ScdFile;
 using ImRaii = OtterGui.Raii.ImRaii;
 
 namespace GatherBuddy.Gui;
@@ -168,6 +170,7 @@ public partial class Interface
         var       alarm   = group.Alarms[alarmIdx];
         using var id      = ImRaii.PushId(alarmIdx);
         var       enabled = alarm.Enabled;
+        var       _sounds = new PlaySound(Dalamud.SigScanner);
 
         ImGui.TableNextColumn();
         if (ImGuiUtil.DrawDisabledButton(FontAwesomeIcon.Trash.ToIconString(), IconButtonSize, "Delete this Alarm...", false, true))
@@ -214,7 +217,10 @@ public partial class Interface
         var idx = alarm.SoundId.ToIdx();
         ImGui.SetNextItemWidth(85 * ImGuiHelpers.GlobalScale);
         if (ImGui.Combo("##Sound", ref idx, AlarmCache.SoundIdNames))
+        {
             _plugin.AlarmManager.ChangeAlarmSound(group, alarmIdx, AlarmCache.SoundIds[idx]);
+            _sounds.Play(AlarmCache.SoundIds[idx]);
+        }
         ImGuiUtil.HoverTooltip("Play this sound effect when this alarm is triggered.");
 
         ImGui.TableNextColumn();

--- a/GatherBuddy/Gui/Interface.AlarmTab.cs
+++ b/GatherBuddy/Gui/Interface.AlarmTab.cs
@@ -13,7 +13,6 @@ using GatherBuddy.Time;
 using ImGuiNET;
 using OtterGui;
 using OtterGui.Widgets;
-using static Lumina.Data.Files.ScdFile;
 using ImRaii = OtterGui.Raii.ImRaii;
 
 namespace GatherBuddy.Gui;
@@ -170,7 +169,6 @@ public partial class Interface
         var       alarm   = group.Alarms[alarmIdx];
         using var id      = ImRaii.PushId(alarmIdx);
         var       enabled = alarm.Enabled;
-        var       _sounds = new PlaySound(Dalamud.SigScanner);
 
         ImGui.TableNextColumn();
         if (ImGuiUtil.DrawDisabledButton(FontAwesomeIcon.Trash.ToIconString(), IconButtonSize, "Delete this Alarm...", false, true))
@@ -219,7 +217,7 @@ public partial class Interface
         if (ImGui.Combo("##Sound", ref idx, AlarmCache.SoundIdNames))
         {
             _plugin.AlarmManager.ChangeAlarmSound(group, alarmIdx, AlarmCache.SoundIds[idx]);
-            _sounds.Play(AlarmCache.SoundIds[idx]);
+            _plugin.AlarmManager.PreviewAlarm(AlarmCache.SoundIds[idx]);
         }
         ImGuiUtil.HoverTooltip("Play this sound effect when this alarm is triggered.");
 


### PR DESCRIPTION
Previews the selected alarm sound on change. Useful to immediately know what the alarm will sound like without checking against the <se.> sound.