### PR TITLE
#203 Fixed certain fishes not being marked as having uptime dependency

### DIFF
--- a/GatherBuddy/Gui/Interface.FishTab.ExtendedFish.cs
+++ b/GatherBuddy/Gui/Interface.FishTab.ExtendedFish.cs
@@ -198,7 +198,7 @@ public partial class Interface
                     if (f.CurrentWeather.Intersect(fish.CurrentWeather).Count() < fish.CurrentWeather.Length)
                         return true;
 
-                    if (f.PreviousWeather.Intersect(fish.PreviousWeather).Count() < fish.PreviousWeather.Length)
+                    if ((f.PreviousWeather.Intersect(fish.PreviousWeather).Count() < fish.PreviousWeather.Length) | fish.PreviousWeather.Length == 0)
                         return true;
                 }
 


### PR DESCRIPTION
Fixed certain fishes not being marked as having uptime dependency

This was done by adding a check to see if the Goal Fish has a weather requirement at all, instead of just checking it against the mooch weather requirements.