### PR TITLE
Add back LureTimer.Stop()

### DIFF
--- a/GatherBuddy/FishTimer/FishRecorder.Record.cs
+++ b/GatherBuddy/FishTimer/FishRecorder.Record.cs
@@ -111,6 +111,7 @@ public partial class FishRecorder
 
         if (Record.Flags.HasLure() && LureTimer.ElapsedMilliseconds >= InvalidLureTiming)
             Record.Flags |= FishRecord.Effects.ValidLure;
+        LureTimer.Stop();
     }
 
     private static readonly uint GatheringIdx =

--- a/GatherBuddy/FishTimer/FishRecorder.cs
+++ b/GatherBuddy/FishTimer/FishRecorder.cs
@@ -124,7 +124,7 @@ public partial class FishRecorder : IDisposable
         data.Data.Remove(record.Bait.Id);
         foreach (var rec in Records.Where(r
                      => r.Flags.HasFlag(FishRecord.Effects.Valid)
-                  && !record.Flags.HasLure()
+                  && (!record.Flags.HasLure() || record.Flags.HasValidLure())
                   && r.Catch?.ItemId == record.Catch.ItemId
                   && r.Bait.Id == record.Bait.Id))
             data.Apply(rec.Bait.Id, rec.Bite, rec.Flags.HasFlag(FishRecord.Effects.Chum));


### PR DESCRIPTION
Hey there! 

Was addressing the issues that @caduceator brought up with the new fishing timer.
Looks like LureTimer.Stop() got removed on accident in one of your cleaning passes! This just adds it back in! Looking to fix any other bugs as well. 