### PR TITLE
Fix stellar hookset being imported as invalid

### DIFF
--- a/GatherBuddy/FishTimer/FishRecord.cs
+++ b/GatherBuddy/FishTimer/FishRecord.cs
@@ -290,7 +290,7 @@ public struct FishRecord
         if ((Flags & ~ValidEffects) != 0)
             return false;
 
-        if ((_tugAndHook & 0x0F) > 4 || ((_tugAndHook >> 4) > 6 && (_tugAndHook >> 4) != 7))
+        if ((_tugAndHook & 0x0F) > 4 || ((_tugAndHook >> 4) >= 6 && (_tugAndHook >> 4) != 7))
             return false;
 
         return true;

--- a/GatherBuddy/FishTimer/FishRecord.cs
+++ b/GatherBuddy/FishTimer/FishRecord.cs
@@ -290,7 +290,7 @@ public struct FishRecord
         if ((Flags & ~ValidEffects) != 0)
             return false;
 
-        if ((_tugAndHook & 0x0F) > 4 || _tugAndHook >> 4 > 6)
+        if ((_tugAndHook & 0x0F) > 4 || ((_tugAndHook >> 4) > 6 && (_tugAndHook >> 4) != 7))
             return false;
 
         return true;


### PR DESCRIPTION
```C#
public void SetTugHook(BiteType bite, HookSet set)
{
    var b = bite switch
    {
        BiteType.None      => 0,
        BiteType.Weak      => 1,
        BiteType.Strong    => 2,
        BiteType.Legendary => 3,
        _                  => 4,
    };
    b |= set switch
    {
        HookSet.None       => 0,
        HookSet.Hook       => 1 << 4,
        HookSet.Precise    => 2 << 4,
        HookSet.Powerful   => 3 << 4,
        HookSet.DoubleHook => 4 << 4,
        HookSet.TripleHook => 5 << 4,
        HookSet.Stellar    => 7 << 4,
        _                  => 6 << 4,
    };
    _tugAndHook = (byte)b;
}
```
This ^ sets the byte (if it was Stellar Hookset + Legendary Bite) to look like `0111 0011` (Legendary bite as an example)

Then when reading back the file, it gets to 
```C#
if ((_tugAndHook & 0x0F) > 4 || _tugAndHook >> 4 > 6)
  return false
```
Which checks if that byte & `0000 1111` is greater than 4. that anded with that is then `0000 0011` which is less than 4 so that passes
But then it shifts the byte to the right 4 times -> `0000 0111` which is then 7 which is greater than 6, so it fails that pass.