### PR TITLE
Update filter and valid checker.

### DIFF
--- a/GatherBuddy/FishTimer/FishRecord.cs
+++ b/GatherBuddy/FishTimer/FishRecord.cs
@@ -290,7 +290,7 @@ public struct FishRecord
         if ((Flags & ~ValidEffects) != 0)
             return false;
 
-        if ((_tugAndHook & 0x0F) > 4 || ((_tugAndHook >> 4) >= 6 && (_tugAndHook >> 4) != 7))
+        if ((_tugAndHook & 0x0F) > 4 || ((_tugAndHook >> 4) > 7))
             return false;
 
         return true;

--- a/GatherBuddy/Gui/Interface.RecordTab.cs
+++ b/GatherBuddy/Gui/Interface.RecordTab.cs
@@ -214,14 +214,15 @@ public partial class Interface
             Weak      = 0x01,
             Strong    = 0x02,
             Legendary = 0x04,
-            Invalid   = 0x08,
+            Unknown   = 0x08,
+            None      = 0x10,
         }
 
         private sealed class BiteTypeHeader : ColumnFlags<TugTypeFilter, FishRecord>
         {
             public BiteTypeHeader()
             {
-                AllFlags = TugTypeFilter.Weak | TugTypeFilter.Strong | TugTypeFilter.Legendary | TugTypeFilter.Invalid;
+                AllFlags = TugTypeFilter.Weak | TugTypeFilter.Strong | TugTypeFilter.Legendary | TugTypeFilter.Unknown | TugTypeFilter.None;
                 _filter  = AllFlags;
             }
 
@@ -250,7 +251,8 @@ public partial class Interface
                     BiteType.Weak      => _filter.HasFlag(TugTypeFilter.Weak),
                     BiteType.Strong    => _filter.HasFlag(TugTypeFilter.Strong),
                     BiteType.Legendary => _filter.HasFlag(TugTypeFilter.Legendary),
-                    _                  => _filter.HasFlag(TugTypeFilter.Invalid),
+                    BiteType.None      => _filter.HasFlag(TugTypeFilter.None),
+                    _                  => _filter.HasFlag(TugTypeFilter.Unknown),
                 };
 
             public override float Width
@@ -265,8 +267,9 @@ public partial class Interface
             Powerful = 0x04,
             Double   = 0x08,
             Triple   = 0x10,
-            Invalid  = 0x20,
+            Unknown  = 0x20,
             Stellar  = 0x40,
+            None     = 0x80,
         }
 
         private sealed class HookHeader : ColumnFlags<HookSetFilter, FishRecord>
@@ -279,7 +282,8 @@ public partial class Interface
                   | HookSetFilter.Double
                   | HookSetFilter.Triple
                   | HookSetFilter.Stellar
-                  | HookSetFilter.Invalid;
+                  | HookSetFilter.Unknown
+                  | HookSetFilter.None;
                 _filter = AllFlags;
             }
 
@@ -311,7 +315,8 @@ public partial class Interface
                     HookSet.DoubleHook => _filter.HasFlag(HookSetFilter.Double),
                     HookSet.TripleHook => _filter.HasFlag(HookSetFilter.Triple),
                     HookSet.Stellar    => _filter.HasFlag(HookSetFilter.Stellar),
-                    _                  => _filter.HasFlag(HookSetFilter.Invalid),
+                    HookSet.None       => _filter.HasFlag(HookSetFilter.None),
+                    _                  => _filter.HasFlag(HookSetFilter.Unknown),
                 };
 
             public override float Width


### PR DESCRIPTION
There are 5 handled Bites:
```
Unknown
Weak
Strong
Legendary
None
```
And there are 8 handled Hooksets (and a 9th Invalid string which shouldn't ever be used?):
```
Unknown
Precise
Powerful
Hook
Double Hook
Triple Hook
Stellar
None
```
(Hopefully they don't add more or GB will need to change from a Byte)

Currently, for bites, Unknown and None are treated the same and are being treated as "Invalid" for the purposes of filtering in the Records tab, then being displayed as None/Unknown. (not as "Invalid" as the filter would lead you to believe.) In theory, this is just a cosmetic change, because users *shouldn't* have Unknown bites or tugs. But if they did, this would help.

So I have changed it to include the proper set of filters (removed and replaced Invalid w/ above) as well as updated the previously changed `frombyte VerifyData` checker to return true for 6 (unknown) and 7 (stellar) cases which are both properly handled. 