### PR TITLE
Change how seconds are displayed in fish timer window (Int -> Rounded Double)

### DIFF
--- a/GatherBuddy/FishTimer/FishTimerWindow.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.cs
@@ -125,7 +125,7 @@ public partial class FishTimerWindow : Window, IDisposable
             drawList.AddLine(start - scale, end - scale, 0x80000000, ImGuiHelpers.GlobalScale);
             drawList.AddLine(start,         end,         0xFFFFFFFF, ImGuiHelpers.GlobalScale);
             drawList.AddLine(start + scale, end + scale, 0x80000000, ImGuiHelpers.GlobalScale);
-            var t = (i * time / 1000).ToString();
+            var t = Math.Round(i * (double)time / 1000, 2).ToString();
             ImGuiUtil.TextShadowed(ImGui.GetWindowDrawList(), end with { X = end.X - ImGui.CalcTextSize(t).X / 2 }, t, 0xFFFFFFFF, 0x80000000);
         }
     }


### PR DESCRIPTION
Fish timer window could be up to nearly a second off of the actual seconds. (Worst case I saw was 0.94 seconds of error.)
![image](https://github.com/user-attachments/assets/71adb05c-fab1-45c3-9532-8d222af192fa)
For the above image, the lowest window represents time 24.361 seconds - 28.842 seconds, but looks much more like 23.5 - 28.1.

Update Version:
![image](https://github.com/user-attachments/assets/93004837-8b9a-44a2-ba08-7b3a681a2f29)
While it is... unpleasant to look at.... it is much more accurate now. Only really looks really bad because of the example however. Users can use sensible numbers (ex: 40 seconds - 7 intervals) to have clean integer numbers.