### PR TITLE
Update 7.2 Data + Small changes changes/fixes

### DIFF
--- a/GatherBuddy.GameData/Classes/Fish.CatchData.cs
+++ b/GatherBuddy.GameData/Classes/Fish.CatchData.cs
@@ -7,27 +7,27 @@ namespace GatherBuddy.Classes;
 
 public partial class Fish
 {
-    public Patch             Patch              { get; internal set; } = Patch.Unknown;
-    public Weather[]         PreviousWeather    { get; internal set; } = [];
-    public Weather[]         CurrentWeather     { get; internal set; } = [];
-    public Bait              InitialBait        { get; internal set; } = Bait.Unknown;
-    public Fish[]            Mooches            { get; internal set; } = [];
-    public (Fish, int)[]     Predators          { get; internal set; } = [];
-    public int               IntuitionLength    { get; internal set; } = 0;
-    public RepeatingInterval Interval           { get; internal set; } = RepeatingInterval.Always;
-    public Snagging          Snagging           { get; internal set; } = Snagging.Unknown;
-    public Lure              Lure               { get; internal set; } = Lure.None;
-    public HookSet           HookSet            { get; internal set; } = HookSet.Unknown;
-    public BiteType          BiteType           { get; internal set; } = BiteType.Unknown;
-    public SpearfishSize     Size               { get; internal set; } = SpearfishSize.Unknown;
-    public SpearfishSpeed    Speed              { get; internal set; } = SpearfishSpeed.Unknown;
-    public Fish?             SurfaceSlap        { get; internal set; }
-    public string            Guide              { get; internal set; } = string.Empty;
-    public OceanTime         OceanTime          { get; internal set; } = OceanTime.Always;
-    public int               MultiHook          { get; internal set; }
-    public int               MultiHookExtension { get; internal set; }
-    public int               Points             { get; internal set; }
-    public bool              LegendaryFish      { get; internal set; } = false;
+    public Patch             Patch                { get; internal set; } = Patch.Unknown;
+    public Weather[]         PreviousWeather      { get; internal set; } = [];
+    public Weather[]         CurrentWeather       { get; internal set; } = [];
+    public Bait              InitialBait          { get; internal set; } = Bait.Unknown;
+    public Fish[]            Mooches              { get; internal set; } = [];
+    public (Fish, int)[]     Predators            { get; internal set; } = [];
+    public int               IntuitionLength      { get; internal set; } = 0;
+    public RepeatingInterval Interval             { get; internal set; } = RepeatingInterval.Always;
+    public Snagging          Snagging             { get; internal set; } = Snagging.Unknown;
+    public Lure              Lure                 { get; internal set; } = Lure.None;
+    public HookSet           HookSet              { get; internal set; } = HookSet.Unknown;
+    public BiteType          BiteType             { get; internal set; } = BiteType.Unknown;
+    public SpearfishSize     Size                 { get; internal set; } = SpearfishSize.Unknown;
+    public SpearfishSpeed    Speed                { get; internal set; } = SpearfishSpeed.Unknown;
+    public Fish?             SurfaceSlap          { get; internal set; }
+    public string            Guide                { get; internal set; } = string.Empty;
+    public OceanTime         OceanTime            { get; internal set; } = OceanTime.Always;
+    public int               MultiHook            { get; internal set; }
+    public int               MultiHookSecondValue { get; internal set; }
+    public int               Points               { get; internal set; }
+    public bool              LegendaryFish        { get; internal set; }
 
     internal OptionalBool BigFishOverride { get; set; } = null;
     

--- a/GatherBuddy.GameData/Classes/Fish.CatchData.cs
+++ b/GatherBuddy.GameData/Classes/Fish.CatchData.cs
@@ -25,6 +25,8 @@ public partial class Fish
     public string            Guide           { get; internal set; } = string.Empty;
     public OceanTime         OceanTime       { get; internal set; } = OceanTime.Always;
     public int               MultiHook       { get; internal set; }
+    public int               Points          { get; internal set; }
 
     internal OptionalBool BigFishOverride { get; set; } = null;
+    internal OptionalBool LegendaryFish   { get; set; } = null;
 }

--- a/GatherBuddy.GameData/Classes/Fish.CatchData.cs
+++ b/GatherBuddy.GameData/Classes/Fish.CatchData.cs
@@ -7,25 +7,26 @@ namespace GatherBuddy.Classes;
 
 public partial class Fish
 {
-    public Patch             Patch           { get; internal set; } = Patch.Unknown;
-    public Weather[]         PreviousWeather { get; internal set; } = [];
-    public Weather[]         CurrentWeather  { get; internal set; } = [];
-    public Bait              InitialBait     { get; internal set; } = Bait.Unknown;
-    public Fish[]            Mooches         { get; internal set; } = [];
-    public (Fish, int)[]     Predators       { get; internal set; } = [];
-    public int               IntuitionLength { get; internal set; } = 0;
-    public RepeatingInterval Interval        { get; internal set; } = RepeatingInterval.Always;
-    public Snagging          Snagging        { get; internal set; } = Snagging.Unknown;
-    public Lure              Lure            { get; internal set; } = Lure.None;
-    public HookSet           HookSet         { get; internal set; } = HookSet.Unknown;
-    public BiteType          BiteType        { get; internal set; } = BiteType.Unknown;
-    public SpearfishSize     Size            { get; internal set; } = SpearfishSize.Unknown;
-    public SpearfishSpeed    Speed           { get; internal set; } = SpearfishSpeed.Unknown;
-    public Fish?             SurfaceSlap     { get; internal set; }
-    public string            Guide           { get; internal set; } = string.Empty;
-    public OceanTime         OceanTime       { get; internal set; } = OceanTime.Always;
-    public int               MultiHook       { get; internal set; }
-    public int               Points          { get; internal set; }
+    public Patch             Patch              { get; internal set; } = Patch.Unknown;
+    public Weather[]         PreviousWeather    { get; internal set; } = [];
+    public Weather[]         CurrentWeather     { get; internal set; } = [];
+    public Bait              InitialBait        { get; internal set; } = Bait.Unknown;
+    public Fish[]            Mooches            { get; internal set; } = [];
+    public (Fish, int)[]     Predators          { get; internal set; } = [];
+    public int               IntuitionLength    { get; internal set; } = 0;
+    public RepeatingInterval Interval           { get; internal set; } = RepeatingInterval.Always;
+    public Snagging          Snagging           { get; internal set; } = Snagging.Unknown;
+    public Lure              Lure               { get; internal set; } = Lure.None;
+    public HookSet           HookSet            { get; internal set; } = HookSet.Unknown;
+    public BiteType          BiteType           { get; internal set; } = BiteType.Unknown;
+    public SpearfishSize     Size               { get; internal set; } = SpearfishSize.Unknown;
+    public SpearfishSpeed    Speed              { get; internal set; } = SpearfishSpeed.Unknown;
+    public Fish?             SurfaceSlap        { get; internal set; }
+    public string            Guide              { get; internal set; } = string.Empty;
+    public OceanTime         OceanTime          { get; internal set; } = OceanTime.Always;
+    public int               MultiHook          { get; internal set; }
+    public int               MultiHookExtension { get; internal set; }
+    public int               Points             { get; internal set; }
 
     internal OptionalBool BigFishOverride { get; set; } = null;
     internal OptionalBool LegendaryFish   { get; set; } = null;

--- a/GatherBuddy.GameData/Classes/Fish.CatchData.cs
+++ b/GatherBuddy.GameData/Classes/Fish.CatchData.cs
@@ -27,7 +27,8 @@ public partial class Fish
     public int               MultiHook          { get; internal set; }
     public int               MultiHookExtension { get; internal set; }
     public int               Points             { get; internal set; }
+    public bool              LegendaryFish      { get; internal set; } = false;
 
     internal OptionalBool BigFishOverride { get; set; } = null;
-    internal OptionalBool LegendaryFish   { get; set; } = null;
+    
 }

--- a/GatherBuddy.GameData/Classes/Fish.cs
+++ b/GatherBuddy.GameData/Classes/Fish.cs
@@ -50,6 +50,9 @@ public partial class Fish : IComparable<Fish>, IGatherable
     public bool IsBigFish
         => BigFishOverride.Value ?? ItemData.Rarity > 1;
 
+    public bool IsLegendaryFish
+        => LegendaryFish.Value ?? false;
+
     public OceanArea OceanArea { get; internal set; } = OceanArea.None;
 
     public bool OceanFish

--- a/GatherBuddy.GameData/Classes/Fish.cs
+++ b/GatherBuddy.GameData/Classes/Fish.cs
@@ -50,9 +50,6 @@ public partial class Fish : IComparable<Fish>, IGatherable
     public bool IsBigFish
         => BigFishOverride.Value ?? ItemData.Rarity > 1;
 
-    public bool IsLegendaryFish
-        => LegendaryFish.Value ?? false;
-
     public OceanArea OceanArea { get; internal set; } = OceanArea.None;
 
     public bool OceanFish

--- a/GatherBuddy.GameData/Data/Fish/Data2.4.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data2.4.cs
@@ -21,6 +21,7 @@ public static partial class Fish
             .Bait      (data, 2606)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Predators (data, 350, (4913, 3))
+            .ForceLegendaryFish(true)
             .Weather   (data, 7, 8);
         data.Apply     (8755, Patch.DreamsOfIce) // Coelacanthus
             .Mooch     (data, 2596, 4898)
@@ -30,6 +31,7 @@ public static partial class Fish
         data.Apply     (8756, Patch.DreamsOfIce) // Endoceras
             .Mooch     (data, 2596, 4898)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .ForceLegendaryFish(true)
             .Time      (1200, 240)
             .Transition(data, 1, 2)
             .Weather   (data, 4, 3, 5);
@@ -65,6 +67,7 @@ public static partial class Fish
         data.Apply     (8763, Patch.DreamsOfIce) // Kuno the Killer
             .Mooch     (data, 2599, 4978, 5002)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .ForceLegendaryFish(true)
             .Predators (data, 1400, (8762, 1));
         data.Apply     (8764, Patch.DreamsOfIce) // Pirate's Bane
             .Mooch     (data, 2585, 4869, 4904)
@@ -89,6 +92,7 @@ public static partial class Fish
         data.Apply     (8768, Patch.DreamsOfIce) // Helicoprion
             .Mooch     (data, 2600, 5035)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .ForceLegendaryFish(true)
             .Time      (480, 1200)
             .Transition(data, 4, 3)
             .Weather   (data, 14);
@@ -110,6 +114,7 @@ public static partial class Fish
             .Weather   (data, 16);
         data.Apply     (8772, Patch.DreamsOfIce) // Shonisaurus
             .Mooch     (data, 2605, 5040, 8771)
+            .ForceLegendaryFish(true)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply     (8773, Patch.DreamsOfIce) // Magicked Mushroom
             .Mooch     (data, 2620, 4995)
@@ -123,6 +128,7 @@ public static partial class Fish
         data.Apply     (8775, Patch.DreamsOfIce) // Namitaro
             .Bait      (data, 2624)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .ForceLegendaryFish(true)
             .Predators (data, 60, (8774, 1));
         data.Apply     (8776, Patch.DreamsOfIce) // Blood Red Bonytongue
             .Mooch     (data, 2599, 4978)

--- a/GatherBuddy.GameData/Data/Fish/Data3.5.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data3.5.cs
@@ -98,6 +98,7 @@ public static partial class Fish
         data.Apply     (17588, Patch.TheFarEdgeOfFate) // Problematicus
             .Mooch     (data, 28634, 12754)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .ForceLegendaryFish(true)
             .Time      (600, 900)
             .Snag      (data, Snagging.None)
             .Predators (data, 180, (12800, 3), (12754, 5))
@@ -105,12 +106,14 @@ public static partial class Fish
         data.Apply     (17589, Patch.TheFarEdgeOfFate) // Opabinia
             .Mooch     (data, 30136, 12776)
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
+            .ForceLegendaryFish(true)
             .Snag      (data, Snagging.None)
             .Predators (data, 105, (13727, 3))
             .Weather   (data, 9);
         data.Apply     (17590, Patch.TheFarEdgeOfFate) // Armor Fish
             .Mooch     (data, 12705, 12757)
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
+            .ForceLegendaryFish(true)
             .Time      (60, 240)
             .Snag      (data, Snagging.None)
             .Predators (data, 160, (12757, 6))
@@ -120,6 +123,7 @@ public static partial class Fish
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
             .Time      (300, 420)
             .Snag      (data, Snagging.None)
+            .ForceLegendaryFish(true)
             .Predators (data, 60, (12810, 3), (12753, 3))
             .Weather   (data, 1);
         data.Apply     (17592, Patch.TheFarEdgeOfFate) // Charibenet
@@ -127,11 +131,13 @@ public static partial class Fish
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
             .Time      (0, 180)
             .Snag      (data, Snagging.None)
+            .ForceLegendaryFish(true)
             .Predators (data, 120, (12715, 5))
             .Weather   (data, 16);
         data.Apply     (17593, Patch.TheFarEdgeOfFate) // Raimdellopterus
             .Mooch     (data, 12712, 12805)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .ForceLegendaryFish(true)
             .Time      (300, 480)
             .Snag      (data, Snagging.None)
             .Predators (data, 100, (12805, 5))

--- a/GatherBuddy.GameData/Data/Fish/Data4.5.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data4.5.cs
@@ -96,31 +96,37 @@ public static partial class Fish
         data.Apply     (24990, Patch.ARequiemForHeroes) // Xenacanthus
             .Mooch     (data, 20675, 24207)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .ForceLegendaryFish(true)
             .Time      (960, 1200);
         data.Apply     (24991, Patch.ARequiemForHeroes) // Drepanaspis
             .Bait      (data, 20619)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Predators (data, 175, (23060, 2))
+            .ForceLegendaryFish(true)
             .Weather   (data, 11);
         data.Apply     (24992, Patch.ARequiemForHeroes) // Stethacanthus
             .Mooch     (data, 20616, 20025)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Time      (960, 1080)
+            .ForceLegendaryFish(true)
             .Predators (data, 350, (20040, 2));
         data.Apply     (24993, Patch.ARequiemForHeroes) // The Ruby Dragon
             .Mooch     (data, 20676, 24214)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Time      (240, 480)
             .Transition(data, 9)
+            .ForceLegendaryFish(true)
             .Weather   (data, 3);
         data.Apply     (24994, Patch.ARequiemForHeroes) // Warden of the Seven Hues
             .Bait      (data, 20675)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .ForceLegendaryFish(true)
             .Predators (data, 175, (23056, 3), (24203, 3), (24204, 5));
         data.Apply     (24995, Patch.ARequiemForHeroes) // The Unconditional
             .Bait      (data, 20675)
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
             .Time      (330, 390)
+            .ForceLegendaryFish(true)
             .Transition(data, 7)
             .Weather   (data, 1);
     }

--- a/GatherBuddy.GameData/Data/Fish/Data5.2.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data5.2.cs
@@ -40,12 +40,15 @@ public static partial class Fish
             .Weather   (data, 2, 1);
         data.Apply     (28937, Patch.EchoesOfAFallenStar) // Galadion Goby
             .Bait      (data, 29714)
+            .Points    (10)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (28938, Patch.EchoesOfAFallenStar) // Galadion Chovy
             .Bait      (data, 29715)
+            .Points    (11)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (28939, Patch.EchoesOfAFallenStar) // Rosy Bream
             .Bait      (data, 29715)
+            .Points    (34)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (28940, Patch.EchoesOfAFallenStar) // Tripod Fish
             .Bait      (data, 29715)
@@ -53,9 +56,11 @@ public static partial class Fish
             .Weather   (data, 2, 15, 16, 1);
         data.Apply     (28941, Patch.EchoesOfAFallenStar) // Sunfly
             .Bait      (data, 29714)
+            .Points    (10)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (28942, Patch.EchoesOfAFallenStar) // Tarnished Shark
             .Bait      (data, 29716)
+            .Points    (34)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Weather   (data, 2, 3, 4, 7, 1);
         data.Apply     (29673, Patch.EchoesOfAFallenStar) // Thinker's Coral
@@ -69,6 +74,7 @@ public static partial class Fish
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29719, Patch.EchoesOfAFallenStar) // Jasperhead
             .Bait      (data, 29715)
+            .Points    (40)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Weather   (data, 2, 7, 8, 1);
         data.Apply     (29720, Patch.EchoesOfAFallenStar) // Merlthor Lobster
@@ -79,23 +85,29 @@ public static partial class Fish
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29722, Patch.EchoesOfAFallenStar) // Ghoul Barracuda
             .Bait      (data, 29715)
+            .Points    (10)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Weather   (data, 2, 3, 4, 1);
         data.Apply     (29723, Patch.EchoesOfAFallenStar) // Leopard Eel
             .Bait      (data, 29716)
+            .Points    (14)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Weather   (data, 2, 3, 4, 1);
         data.Apply     (29724, Patch.EchoesOfAFallenStar) // Marine Bomb
             .Bait      (data, 29715)
+            .Points    (27)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29725, Patch.EchoesOfAFallenStar) // Momora Mora
             .Bait      (data, 29716)
+            .Points    (22)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply     (29726, Patch.EchoesOfAFallenStar) // Merlthor Butterfly
             .Bait      (data, 29714)
+            .Points    (22)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29727, Patch.EchoesOfAFallenStar) // Gladius
             .Mooch     (data, 29715, 29722)
+            .Points    (49)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (29728, Patch.EchoesOfAFallenStar) // Rhotano Wahoo
             .Bait      (data, 29715)
@@ -120,6 +132,7 @@ public static partial class Fish
             .Weather   (data, 2, 11, 14, 1);
         data.Apply     (29734, Patch.EchoesOfAFallenStar) // Cyan Octopus
             .Bait      (data, 29715)
+            .Points    (59)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (29735, Patch.EchoesOfAFallenStar) // Chrome Hammerhead
             .Bait      (data, 29716)
@@ -136,9 +149,11 @@ public static partial class Fish
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (29739, Patch.EchoesOfAFallenStar) // La Noscean Jelly
             .Bait      (data, 29714)
+            .Points    (10)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29740, Patch.EchoesOfAFallenStar) // Shaggy Seadragon
             .Bait      (data, 29714)
+            .Points    (35)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Weather   (data, 2, 5, 6, 1);
         data.Apply     (29741, Patch.EchoesOfAFallenStar) // Net Crawler
@@ -156,6 +171,7 @@ public static partial class Fish
             .Predators (data, 60, (28938, 3));
         data.Apply     (29745, Patch.EchoesOfAFallenStar) // Little Leviathan
             .Bait      (data, 29716)
+            .Points    (204)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Predators (data, 60, (29727, 1));
         data.Apply     (29746, Patch.EchoesOfAFallenStar) // Sabaton
@@ -171,47 +187,60 @@ public static partial class Fish
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29749, Patch.EchoesOfAFallenStar) // Heavenskey
             .Bait      (data, 29714)
+            .Points    (67)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29750, Patch.EchoesOfAFallenStar) // Ghost Shark
             .Bait      (data, 29716)
+            .Points    (78)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (29751, Patch.EchoesOfAFallenStar) // Quicksilver Blade
             .Bait      (data, 29716)
+            .Points    (213)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (29752, Patch.EchoesOfAFallenStar) // Navigator's Print
             .Bait      (data, 29715)
+            .Points    (71)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29753, Patch.EchoesOfAFallenStar) // Casket Oyster
             .Bait      (data, 29714)
+            .Points    (222)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Ocean     (OceanTime.Day);
         data.Apply     (29754, Patch.EchoesOfAFallenStar) // Fishmonger
             .Bait      (data, 29716)
+            .Points    (78)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (29755, Patch.EchoesOfAFallenStar) // Mythril Sovereign
             .Bait      (data, 29715)
+            .Points    (196)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Ocean     (OceanTime.Day);
         data.Apply     (29756, Patch.EchoesOfAFallenStar) // Nimble Dancer
             .Bait      (data, 29714)
+            .Points    (444)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Ocean     (OceanTime.Day);
         data.Apply     (29757, Patch.EchoesOfAFallenStar) // Sea Nettle
             .Bait      (data, 29714)
+            .Points    (156)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (29758, Patch.EchoesOfAFallenStar) // Great Grandmarlin
             .Mooch     (data, 29714, 29761)
+            .Points    (127)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (29759, Patch.EchoesOfAFallenStar) // Shipwreck's Sail
             .Bait      (data, 29716)
+            .Points    (59)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (29760, Patch.EchoesOfAFallenStar) // Azeyma's Sleeve
             .Bait      (data, 29715)
+            .Points    (69)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29761, Patch.EchoesOfAFallenStar) // Hi-aetherlouse
             .Bait      (data, 29714)
+            .Points    (65)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29762, Patch.EchoesOfAFallenStar) // Floating Saucer
             .Bait      (data, 29715)
@@ -219,6 +248,7 @@ public static partial class Fish
             .Ocean     (OceanTime.Night);
         data.Apply     (29763, Patch.EchoesOfAFallenStar) // Aetheric Seadragon
             .Mooch     (data, 29714, 29761)
+            .Points    (245)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Ocean     (OceanTime.Night);
         data.Apply     (29764, Patch.EchoesOfAFallenStar) // Coral Seadragon
@@ -228,9 +258,11 @@ public static partial class Fish
         data.Apply     (29765, Patch.EchoesOfAFallenStar) // Roguesaurus
             .Mooch     (data, 29714, 29761)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Points    (345)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (29766, Patch.EchoesOfAFallenStar) // Merman's Mane
             .Bait      (data, 29715)
+            .Points    (94)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (29767, Patch.EchoesOfAFallenStar) // Sweeper
             .Bait      (data, 29716)
@@ -275,6 +307,7 @@ public static partial class Fish
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29779, Patch.EchoesOfAFallenStar) // Charlatan Survivor
             .Bait      (data, 29715)
+            .Points    (69)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29780, Patch.EchoesOfAFallenStar) // Prodigal Son
             .Bait      (data, 29715)
@@ -284,6 +317,7 @@ public static partial class Fish
             .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply     (29782, Patch.EchoesOfAFallenStar) // Funnel Shark
             .Bait      (data, 29716)
+            .Points    (213)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (29783, Patch.EchoesOfAFallenStar) // The Fallen One
@@ -292,27 +326,33 @@ public static partial class Fish
             .Ocean     (OceanTime.Sunset);
         data.Apply     (29784, Patch.EchoesOfAFallenStar) // Spectral Megalodon
             .Bait      (data, 29715)
+            .Points    (100)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Weather   (data, 2, 3, 4, 7, 8);
         data.Apply     (29785, Patch.EchoesOfAFallenStar) // Spectral Discus
             .Bait      (data, 29715)
+            .Points    (100)
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
             .Weather   (data, 2, 3, 4, 5, 6);
         data.Apply     (29786, Patch.EchoesOfAFallenStar) // Spectral Sea Bo
             .Bait      (data, 29714)
+            .Points    (100)
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
             .Weather   (data, 2, 3, 4, 15, 16);
         data.Apply     (29787, Patch.EchoesOfAFallenStar) // Spectral Bass
             .Bait      (data, 29716)
+            .Points    (100)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Weather   (data, 2, 3, 4, 11, 14);
         data.Apply     (29788, Patch.EchoesOfAFallenStar) // Sothis
             .Bait      (data, 2603)
+            .Points    (500)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Ocean     (OceanTime.Night)
             .Predators (data, 15, (29749, 2), (29752, 1));
         data.Apply     (29789, Patch.EchoesOfAFallenStar) // Coral Manta
             .Bait      (data, 2613)
+            .Points    (500)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Ocean     (OceanTime.Night)
             .Predators (data, 15, (29758, 2));

--- a/GatherBuddy.GameData/Data/Fish/Data5.4.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data5.4.cs
@@ -50,142 +50,182 @@ public static partial class Fish
             .Weather   (data, 3);
         data.Apply     (32055, Patch.FuturesRewritten) // Tortoiseshell Crab
             .Bait      (data, 29715)
+            .Points    (10)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (32056, Patch.FuturesRewritten) // Lady's Cameo
             .Bait      (data, 29714)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Points    (15)
             .Weather   (data, 2, 3, 4, 1);
         data.Apply     (32057, Patch.FuturesRewritten) // Metallic Boxfish
             .Bait      (data, 29714)
+            .Points    (9)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (32058, Patch.FuturesRewritten) // Goobbue Ray
             .Bait      (data, 29716)
+            .Points    (33)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (32059, Patch.FuturesRewritten) // Watermoura
             .Bait      (data, 29715)
+            .Points    (41)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Weather   (data, 2, 3, 4, 9, 1);
         data.Apply     (32060, Patch.FuturesRewritten) // King Cobrafish
             .Bait      (data, 29716)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Points    (39)
             .Weather   (data, 2, 9, 10, 1);
         data.Apply     (32061, Patch.FuturesRewritten) // Mamahi-mahi
             .Bait      (data, 29716)
+            .Points    (58)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply     (32062, Patch.FuturesRewritten) // Lavandin Remora
             .Bait      (data, 29715)
+            .Points    (52)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (32063, Patch.FuturesRewritten) // Spectral Butterfly
             .Bait      (data, 29714)
+            .Points    (100)
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
             .Weather   (data, 2, 3, 4, 9, 10);
         data.Apply     (32064, Patch.FuturesRewritten) // Cieldalaes Geode
             .Bait      (data, 29715)
+            .Points    (246)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Predators (data, 60, (32057, 3));
         data.Apply     (32065, Patch.FuturesRewritten) // Titanshell Crab
             .Bait      (data, 29715)
+            .Points    (84)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (32066, Patch.FuturesRewritten) // Mythril Boxfish
             .Bait      (data, 29714)
+            .Points    (64)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (32067, Patch.FuturesRewritten) // Mistbeard's Cup
             .Bait      (data, 29715)
+            .Points    (84)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (32068, Patch.FuturesRewritten) // Anomalocaris Saron
             .Bait      (data, 29715)
+            .Points    (84)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (32069, Patch.FuturesRewritten) // Flaming Eel
             .Bait      (data, 29715)
+            .Points    (198)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (32070, Patch.FuturesRewritten) // Jetborne Manta
             .Bait      (data, 29716)
+            .Points    (75)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply     (32071, Patch.FuturesRewritten) // Devil's Sting
             .Bait      (data, 29715)
+            .Points    (201)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Ocean     (OceanTime.Day);
         data.Apply     (32072, Patch.FuturesRewritten) // Callichthyid
             .Bait      (data, 29716)
+            .Points    (178)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Ocean     (OceanTime.Day);
         data.Apply     (32073, Patch.FuturesRewritten) // Meandering Mora
             .Bait      (data, 29716)
+            .Points    (283)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (32074, Patch.FuturesRewritten) // Hafgufa
             .Bait      (data, 27590)
+            .Points    (500)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Ocean     (OceanTime.Night)
             .Predators (data, 15, (32070, 2), (32067, 1));
         data.Apply     (32075, Patch.FuturesRewritten) // Thaliak Crab
             .Bait      (data, 29714)
+            .Points    (9)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (32076, Patch.FuturesRewritten) // Star of the Destroyer
             .Bait      (data, 29714)
+            .Points    (14)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Weather   (data, 2, 3, 4, 1);
         data.Apply     (32077, Patch.FuturesRewritten) // True Scad
             .Bait      (data, 29715)
+            .Points    (8)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (32078, Patch.FuturesRewritten) // Blooded Wrasse
             .Bait      (data, 29716)
+            .Points    (35)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Weather   (data, 2, 3, 4, 7, 1);
         data.Apply     (32079, Patch.FuturesRewritten) // Bloodpolish Crab
             .Bait      (data, 29714)
+            .Points    (28)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (32080, Patch.FuturesRewritten) // Blue Stitcher
             .Bait      (data, 29715)
+            .Points    (30)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Weather   (data, 2, 7, 8, 1);
         data.Apply     (32081, Patch.FuturesRewritten) // Bloodfresh Tuna
             .Bait      (data, 29716)
+            .Points    (43)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (32082, Patch.FuturesRewritten) // Sunken Mask
             .Bait      (data, 29714)
+            .Points    (49)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply     (32083, Patch.FuturesRewritten) // Spectral Eel
             .Bait      (data, 29715)
+            .Points    (100)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Weather   (data, 2, 3, 4, 7, 8);
         data.Apply     (32084, Patch.FuturesRewritten) // Bareface
             .Bait      (data, 29715)
+            .Points    (326)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Predators (data, 60, (32082, 1));
         data.Apply     (32085, Patch.FuturesRewritten) // Oracular Crab
             .Bait      (data, 29714)
+            .Points    (102)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Ocean     (OceanTime.Day);
         data.Apply     (32086, Patch.FuturesRewritten) // Dravanian Bream
             .Bait      (data, 29715)
+            .Points    (77)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (32087, Patch.FuturesRewritten) // Skaldminni
             .Bait      (data, 29715)
+            .Points    (102)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Ocean     (OceanTime.Night);
         data.Apply     (32088, Patch.FuturesRewritten) // Serrated Clam
             .Bait      (data, 29714)
+            .Points    (74)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (32089, Patch.FuturesRewritten) // Beatific Vision
             .Bait      (data, 29715)
+            .Points    (77)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (32090, Patch.FuturesRewritten) // Exterminator
             .Bait      (data, 29714)
+            .Points    (255)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Ocean     (OceanTime.Day);
         data.Apply     (32091, Patch.FuturesRewritten) // Gory Tuna
             .Bait      (data, 29716)
+            .Points    (92)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (32092, Patch.FuturesRewritten) // Ticinepomis
             .Bait      (data, 29716)
+            .Points    (92)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply     (32093, Patch.FuturesRewritten) // Quartz Hammerhead
             .Bait      (data, 29716)
+            .Points    (460)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply     (32094, Patch.FuturesRewritten) // Seafaring Toad
             .Bait      (data, 2587)
+            .Points    (500)
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
             .Ocean     (OceanTime.Day)
             .Predators (data, 15, (32089, 3));

--- a/GatherBuddy.GameData/Data/Fish/Data5.5.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data5.5.cs
@@ -25,6 +25,7 @@ public static partial class Fish
         data.Apply     (33239, Patch.DeathUntoDawn) // Listracanthus
             .Mooch     (data, 27589, 28925)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .ForceLegendaryFish(true)
             .Time      (960, 1440)
             .Transition(data, 1, 2)
             .Weather   (data, 4);
@@ -32,11 +33,13 @@ public static partial class Fish
             .Bait      (data, 27588)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Time      (600, 960)
+            .ForceLegendaryFish(true)
             .Predators (data, 350, (33319, 1), (27452, 5));
         data.Apply     (33241, Patch.DeathUntoDawn) // Cinder Surprise
             .Bait      (data, 27584)
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
             .Time      (0, 120)
+            .ForceLegendaryFish(true)
             .Predators (data, 360, (27462, 10))
             .Transition(data, 11)
             .Weather   (data, 14);
@@ -44,15 +47,18 @@ public static partial class Fish
             .Bait      (data, 27589)
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
             .Time      (1410, 1440)
+            .ForceLegendaryFish(true)
             .Transition(data, 10)
             .Weather   (data, 1);
         data.Apply     (33243, Patch.DeathUntoDawn) // Greater Serpent of Ronka
             .Mooch     (data, 27587, 27490, 27491, 28071)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .ForceLegendaryFish(true)
             .Time      (600, 720);
         data.Apply     (33244, Patch.DeathUntoDawn) // Lancetfish
             .Bait      (data, 27590)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .ForceLegendaryFish(true)
             .Time      (0, 120)
             .Predators (data, 700, (33325, 2))
             .Transition(data, 2)

--- a/GatherBuddy.GameData/Data/Fish/Data6.5.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data6.5.cs
@@ -80,6 +80,7 @@ public static partial class Fish
         data.Apply(41407, Patch.GrowingLight) // Hyphalosaurus
             .Mooch(data, 36412)
             .Time(540, 720)
+            .ForceLegendaryFish(true)
             .Predators(data, 90, (36412, 3))
             .Transition(data, 1)
             .Weather(data, 2)
@@ -87,6 +88,7 @@ public static partial class Fish
         data.Apply(41408, Patch.GrowingLight) // Gharlichthys
             .Bait(data, 36593)
             .Time(840, 960)
+            .ForceLegendaryFish(true)
             .Predators(data, 300, (36454, 12))
             .Transition(data, 8)
             .Weather(data, 2)
@@ -94,6 +96,7 @@ public static partial class Fish
         data.Apply(41409, Patch.GrowingLight) // Snowy Parexus
             .Bait(data, 36591)
             .Time(960, 1440)
+            .ForceLegendaryFish(true)
             .Predators(data, 35, (36458, 3))
             .Transition(data, 2)
             .Weather(data, 15)
@@ -102,6 +105,7 @@ public static partial class Fish
             .Bait(data, 36590)
             .Time(930, 990)
             .Transition(data, 2)
+            .ForceLegendaryFish(true)
             .Weather(data, 49)
             .Bite(data, HookSet.Precise, BiteType.Legendary);
         data.Apply(41411, Patch.GrowingLight) // Lopoceras Elegans
@@ -109,10 +113,12 @@ public static partial class Fish
             .Time(480, 600)
             .Transition(data, 148)
             .Weather(data, 2)
+            .ForceLegendaryFish(true)
             .Bite(data, HookSet.Powerful, BiteType.Legendary);
         data.Apply(41412, Patch.GrowingLight) // Sidereal Whale
             .Mooch(data, 36518)
             .Time(0, 480)
+            .ForceLegendaryFish(true)
             .Predators(data, 600, (36521, 1), (36520, 2), (36519, 3))
             .Transition(data, 49)
             .Weather(data, 149)

--- a/GatherBuddy.GameData/Data/Fish/Data7.2.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data7.2.cs
@@ -94,14 +94,17 @@ public static partial class Fish
         data.Apply(45702, Patch.SeekersOfEternity) // Star Pleco
             .Bait(data, 45947)
             .Mission(data, 454)
+            .Points(50)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45703, Patch.SeekersOfEternity) // Lunar Axolotl
             .Bait(data, 45947)
             .Mission(data, 454)
+            .Points(150)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45704, Patch.SeekersOfEternity) // Lunar Catfish
             .Bait(data, 45947)
             .Mission(data, 454)
+            .Points(300)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
 
         // Weeping Pool  Weeping Pool Ecological Survey
@@ -172,18 +175,22 @@ public static partial class Fish
         data.Apply(45719, Patch.SeekersOfEternity) // Bluemoon Loach
             .Bait(data, 45949)
             .Mission(data, 459)
+            .Points(100)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45720, Patch.SeekersOfEternity) // Lunar Raiamas
             .Bait(data, 45949)
             .Mission(data, 459)
+            .Points(100)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45721, Patch.SeekersOfEternity) // Lunar Salmon
             .Bait(data, 45949)
             .Mission(data, 459)
+            .Points(200)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45722, Patch.SeekersOfEternity) // Lunar Aetherlouse
             .Bait(data, 45949)
             .Mission(data, 459)
+            .Points(150)
             .Bite(data, HookSet.Precise, BiteType.Weak);
 
         // Southeast Well  Southeast Well Ecological Survey
@@ -285,22 +292,27 @@ public static partial class Fish
         data.Apply(45744, Patch.SeekersOfEternity) // Astacus Lamentorum
             .Bait(data, 45952)
             .Mission(data, 465)
+            .Points(50)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45745, Patch.SeekersOfEternity) // Starcrier
             .Bait(data, 45952)
             .Mission(data, 465)
+            .Points(100)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45746, Patch.SeekersOfEternity) // Rainbow Tear
             .Bait(data, 45952)
             .Mission(data, 465)
+            .Points(150)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45747, Patch.SeekersOfEternity) // Ammoonite
             .Bait(data, 45952)
             .Mission(data, 465)
+            .Points(200)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45748, Patch.SeekersOfEternity) // Lunar Coelacanth
             .Bait(data, 45952)
             .Mission(data, 465)
+            .Points(500)
             .Bite(data, HookSet.Powerful, BiteType.Legendary);
 
         // Hollow Harbor  Hollow Harbor Ecological Survey
@@ -519,14 +531,17 @@ public static partial class Fish
         data.Apply(45796, Patch.SeekersOfEternity) // Polypus Arsenici
             .Bait(data, 45963)
             .Mission(data, 475)
+            .Points(150)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45797, Patch.SeekersOfEternity) // Broodingway
             .Bait(data, 45963)
             .Mission(data, 475)
+            .Points(400)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45798, Patch.SeekersOfEternity) // Galactic Haze
             .Bait(data, 45963)
             .Mission(data, 475)
+            .Points(600)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
 
         // Hollow Harbor A-1: Fine-grade Aquatic Processing Materials
@@ -625,25 +640,32 @@ public static partial class Fish
 
         // Glimmerpond Alpha A-2: Foodstuff Emergency
         data.Apply(45836, Patch.SeekersOfEternity) // Arsenic Axolotl
-            .Bait(data)
+            .Bait(data, 45962)
             .Mission(data, 480)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Weather(data, 148)
+            .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45837, Patch.SeekersOfEternity) // Sunny Jellyfish
-            .Bait(data)
+            .Bait(data, 45962)
             .Mission(data, 480)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Weather(data, 148)
+            .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45838, Patch.SeekersOfEternity) // Universal Darkfin
-            .Bait(data)
+            .Bait(data, 45962)
             .Mission(data, 480)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Weather(data, 148)
+            .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45839, Patch.SeekersOfEternity) // Etheirys Croppie
-            .Bait(data)
+            .Bait(data, 45962)
             .Mission(data, 480)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .MultiHook(2)
+            .Weather(data, 148)
+            .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45840, Patch.SeekersOfEternity) // Moon Mora
-            .Bait(data)
+            .Bait(data, 45962)
             .Mission(data, 480)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .MultiHook(4)
+            .Weather(data, 148)
+            .Bite(data, HookSet.Powerful, BiteType.Legendary);
 
         // Palus Arsenici A-3: Palus Arsenici Ecological Survey
         data.Apply(45865, Patch.SeekersOfEternity) // Lunar Scorpion
@@ -809,79 +831,91 @@ public static partial class Fish
         data.Apply(45877, Patch.SeekersOfEternity) // Moonrock Candy
             .Bait(data, 45961)
             .Mission(data, 487)
+            .Points(100)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45878, Patch.SeekersOfEternity) // Moongill
             .Bait(data, 45961)
             .Mission(data, 487)
+            .Points(100)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45879, Patch.SeekersOfEternity) // Darkside Bass
             .Bait(data, 45961)
             .Mission(data, 487)
+            .Points(100)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45880, Patch.SeekersOfEternity) // Opal Guppy
             .Bait(data, 45961)
             .Mission(data, 487)
+            .Points(400)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45881, Patch.SeekersOfEternity) // Harbor Fang
             .Bait(data, 45961)
             .Mission(data, 487)
+            .Points(600)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45882, Patch.SeekersOfEternity) // Deepmoon Cabomba
             .Bait(data, 45961)
             .Mission(data, 487)
+            .Points(1000)
             .Bite(data, HookSet.Precise, BiteType.Weak);
 
         // Northward Hop-print A-2: Coexisting Species I
         data.Apply(45853, Patch.SeekersOfEternity) // Melancholia
             .Bait(data, 45960)
             .Mission(data, 488)
+            .Points(50)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45857, Patch.SeekersOfEternity) // Mooncrystal Perch
             .Bait(data, 45960)
             .Mission(data, 488)
+            .Points(100)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45854, Patch.SeekersOfEternity) // Lunar Prismfish
             .Bait(data, 45960)
             .Mission(data, 488)
+            .Points(150)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45855, Patch.SeekersOfEternity) // Hopping Flounder
             .Bait(data, 45960)
             .Mission(data, 488)
+            .Points(400)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45858, Patch.SeekersOfEternity) // Cobalt Fish
             .Bait(data, 45960)
             .Mission(data, 488)
+            .Points(500)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45856, Patch.SeekersOfEternity) // Galactic Flarefish
             .Bait(data, 45960)
             .Mission(data, 488)
+            .Points(1000)
             .Bite(data, HookSet.Powerful, BiteType.Legendary);
 
         // Glimmerpond Alpha A-3: Coexisting Species II
         data.Apply(45883, Patch.SeekersOfEternity) // Arsenic Axolotl
-            .Bait(data)
+            .Bait(data, 45963)
             .Mission(data, 489)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Unknown, BiteType.Weak);
         data.Apply(45884, Patch.SeekersOfEternity) // Sunny Jellyfish
-            .Bait(data)
+            .Bait(data, 45963)
             .Mission(data, 489)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Unknown, BiteType.Strong);
         data.Apply(45885, Patch.SeekersOfEternity) // Universal Darkfin
-            .Bait(data)
+            .Bait(data, 45963)
             .Mission(data, 489)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Unknown, BiteType.Weak);
         data.Apply(45886, Patch.SeekersOfEternity) // Glimmerfish
-            .Bait(data)
+            .Bait(data, 45963)
             .Mission(data, 489)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Unknown, BiteType.Strong);
         data.Apply(45887, Patch.SeekersOfEternity) // Lepopredator
-            .Bait(data)
+            .Bait(data, 45963)
             .Mission(data, 489)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45888, Patch.SeekersOfEternity) // Soliclymenia
-            .Bait(data)
+            .Bait(data, 45963)
             .Mission(data, 489)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Powerful, BiteType.Legendary);
 
         // Palus Arsenici A-1: Aetherochemical Samples I
         data.Apply(45815, Patch.SeekersOfEternity) // Lunar Scorpion
@@ -914,27 +948,27 @@ public static partial class Fish
         data.Apply(45859, Patch.SeekersOfEternity) // Lunar Goldfish
             .Bait(data)
             .Mission(data, 491)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Unknown, BiteType.Weak);
         data.Apply(45860, Patch.SeekersOfEternity) // Lunar Minnow
             .Bait(data)
             .Mission(data, 491)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Unknown, BiteType.Strong);
         data.Apply(45861, Patch.SeekersOfEternity) // Gleamingray
             .Bait(data)
             .Mission(data, 491)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Unknown, BiteType.Strong);
         data.Apply(45862, Patch.SeekersOfEternity) // Lunar Butterfly
             .Bait(data)
             .Mission(data, 491)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Unknown, BiteType.Weak);
         data.Apply(45863, Patch.SeekersOfEternity) // Lunar Seagrapes
             .Bait(data)
             .Mission(data, 491)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Unknown, BiteType.Legendary);
         data.Apply(45864, Patch.SeekersOfEternity) // Fishingway
             .Bait(data)
             .Mission(data, 491)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Unknown, BiteType.Legendary);
 
         // Aetherial Falls A-3: Aetherochemical Samples III
         data.Apply(45889, Patch.SeekersOfEternity) // Ctenophora Lunaris
@@ -1101,15 +1135,16 @@ public static partial class Fish
         data.Apply(45926, Patch.SeekersOfEternity) // Darkside Shrimp
             .Bait(data)
             .Mission(data, 510)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45927, Patch.SeekersOfEternity) // Stardust Octopus
             .Bait(data)
             .Mission(data, 510)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45928, Patch.SeekersOfEternity) // Raw Moonbright Tourmaline
             .Bait(data)
             .Mission(data, 510)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .MultiHook(4)
+            .Bite(data, HookSet.Powerful, BiteType.Strong);
 
         // Hollow Harbor A-3: Eel Rations
         data.Apply(45929, Patch.SeekersOfEternity) // Moonrock Candy
@@ -1123,19 +1158,19 @@ public static partial class Fish
         data.Apply(45931, Patch.SeekersOfEternity) // Waxscale
             .Bait(data)
             .Mission(data, 511)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45932, Patch.SeekersOfEternity) // Corydoras Lunaris
             .Bait(data)
             .Mission(data, 511)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45933, Patch.SeekersOfEternity) // Infinity Eel
             .Bait(data)
             .Mission(data, 511)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(45934, Patch.SeekersOfEternity) // Hollow Eel
             .Bait(data)
             .Mission(data, 511)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Powerful, BiteType.Strong);
 
         // Westward Hop-print  Edible Fish
         data.Apply(45935, Patch.SeekersOfEternity) // Bluemoon Loach
@@ -1145,11 +1180,11 @@ public static partial class Fish
         data.Apply(45936, Patch.SeekersOfEternity) // Lamentorum Geayi
             .Bait(data)
             .Mission(data, 542)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(45937, Patch.SeekersOfEternity) // Moon Bluetail
             .Bait(data)
             .Mission(data, 542)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bite(data, HookSet.Powerful, BiteType.Strong);
 
         // Northward Hop-print  Sunken Drone Salvage
         data.Apply(45938, Patch.SeekersOfEternity) // Melancholia

--- a/GatherBuddy.GameData/Data/Fish/DataBase.cs
+++ b/GatherBuddy.GameData/Data/Fish/DataBase.cs
@@ -294,6 +294,16 @@ public static partial class Fish
         fish.MultiHook = value;
         return fish;
     }
+    
+    private static Classes.Fish? MultiHook(this Classes.Fish? fish, int value, int value2)
+    {
+        if (fish == null)
+            return null;
+
+        fish.MultiHook = value;
+        fish.MultiHookExtension = value2;
+        return fish;
+    }
 
     private static Classes.Fish? Points(this Classes.Fish? fish, int value)
     {

--- a/GatherBuddy.GameData/Data/Fish/DataBase.cs
+++ b/GatherBuddy.GameData/Data/Fish/DataBase.cs
@@ -256,6 +256,15 @@ public static partial class Fish
         fish.BigFishOverride = value;
         return fish;
     }
+    
+    private static Classes.Fish? ForceLegendaryFish(this Classes.Fish? fish, bool value)
+    {
+        if (fish == null)
+            return null;
+        
+        fish.LegendaryFish = value;
+        return fish;
+    }
 
     private static Classes.Fish? Slap(this Classes.Fish? fish, GameData data, uint fishId)
     {
@@ -283,6 +292,15 @@ public static partial class Fish
             return null;
 
         fish.MultiHook = value;
+        return fish;
+    }
+
+    private static Classes.Fish? Points(this Classes.Fish? fish, int value)
+    {
+        if (fish == null)
+            return null;
+        
+        fish.Points = value;
         return fish;
     }
 

--- a/GatherBuddy.GameData/Data/Fish/DataBase.cs
+++ b/GatherBuddy.GameData/Data/Fish/DataBase.cs
@@ -301,7 +301,7 @@ public static partial class Fish
             return null;
 
         fish.MultiHook = value;
-        fish.MultiHookExtension = value2;
+        fish.MultiHookSecondValue = value2;
         return fish;
     }
 

--- a/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
@@ -124,7 +124,7 @@ public partial class FishTimerWindow
             // Some non-spectral ocean fish have weather restrictions, but this is not handled.
             var hasWeatherRestriction = fish.FishRestrictions.HasFlag(FishRestrictions.Weather) && !fish.OceanFish;
             if (GatherBuddy.Time.ServerTime < uptime.Start
-             && (!flags.HasFlag(FishRecord.Effects.FishEyes) || fish.IsBigFish || hasWeatherRestriction))
+             && (!flags.HasFlag(FishRecord.Effects.FishEyes) || fish.IsLegendaryFish || hasWeatherRestriction || fish.Patch < Patch.Endwalker))
                 Unavailable = true;
             if (fish.Snagging == Snagging.Required && !flags.HasFlag(FishRecord.Effects.Snagging))
                 Unavailable = true;

--- a/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
@@ -227,7 +227,7 @@ public partial class FishTimerWindow
             var       clipRectMin = ImGui.GetCursorScreenPos();
             var       clipRectMax = clipRectMin + ImGui.GetContentRegionAvail();
             var       collectible = _fish.Collectible && GatherBuddy.Config.ShowCollectableHints;
-            var       multiHook   = _fish.DoubleHook > 1 && GatherBuddy.Config.ShowMultiHookHints;
+            var       multiHook   = _fish.MultiHook > 1 && GatherBuddy.Config.ShowMultiHookHints;
             if (collectible)
                 clipRectMax.X -= window._iconSize.X;
             if (multiHook)
@@ -256,7 +256,7 @@ public partial class FishTimerWindow
             {
                 ImGui.SameLine(window._windowSize.X - window._iconSize.X);
 
-                var hookIcon = _fish.DoubleHook switch
+                var hookIcon = _fish.MultiHook switch
                 {
                     2 => DoubleHookIcon,
                     3 => TripleHookIcon,
@@ -272,17 +272,17 @@ public partial class FishTimerWindow
                         using var tooltip = ImRaii.Tooltip();
                         window._style.Push(ImGuiStyleVar.ItemSpacing, window._originalSpacing);
                         
-                        if (_fish.DoubleHookExtension < 1)
+                        if (_fish.MutliHookSecondValue < 1)
                         {
-                            ImUtf8.Text($"Double Hook for {_fish.DoubleHook} fish{(_fish.Points > 0 ? $" worth {_fish.Points * _fish.DoubleHook} points" : "")}");
-                            ImUtf8.Text($"Triple Hook for {2 * _fish.DoubleHook - 1} fish{(_fish.Points > 0 ? $" worth {_fish.Points * (2 * _fish.DoubleHook - 1)} points" : "")}");
+                            ImUtf8.Text($"Double Hook for {_fish.MultiHook} fish{(_fish.Points > 0 ? $" worth {_fish.Points * _fish.MultiHook} points" : "")}");
+                            ImUtf8.Text($"Triple Hook for {2 * _fish.MultiHook - 1} fish{(_fish.Points > 0 ? $" worth {_fish.Points * (2 * _fish.MultiHook - 1)} points" : "")}");
                         }
                         else
                         {
-                            ImUtf8.Text($"Double Hook for {_fish.DoubleHook}-{_fish.DoubleHookExtension} fish" +
-                                $"{(_fish.Points > 0 ? $" worth between {_fish.Points * _fish.DoubleHook} and {_fish.Points * _fish.DoubleHookExtension} points" : "")}");
-                            ImUtf8.Text($"Triple Hook for {2 * _fish.DoubleHook - 1}-{2 * _fish.DoubleHookExtension - 1} fish" +
-                                $"{(_fish.Points > 0 ? $" worth between {_fish.Points * (2 * _fish.DoubleHook - 1)} and {_fish.Points * (2 * _fish.DoubleHookExtension - 1)} points" : "")}");
+                            ImUtf8.Text($"Double Hook for {_fish.MultiHook}-{_fish.MutliHookSecondValue} fish" +
+                                $"{(_fish.Points > 0 ? $" worth between {_fish.Points * _fish.MultiHook} and {_fish.Points * _fish.MutliHookSecondValue} points" : "")}");
+                            ImUtf8.Text($"Triple Hook for {2 * _fish.MultiHook - 1}-{2 * _fish.MutliHookSecondValue - 1} fish" +
+                                $"{(_fish.Points > 0 ? $" worth between {_fish.Points * (2 * _fish.MultiHook - 1)} and {_fish.Points * (2 * _fish.MutliHookSecondValue - 1)} points" : "")}");
                         }
 
                         window._style.Pop();

--- a/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
@@ -271,8 +271,20 @@ public partial class FishTimerWindow
                     {
                         using var tooltip = ImRaii.Tooltip();
                         window._style.Push(ImGuiStyleVar.ItemSpacing, window._originalSpacing);
-                        ImUtf8.Text($"Double Hook for {_fish.DoubleHook} fish.");
-                        ImUtf8.Text($"Triple Hook for {2 * _fish.DoubleHook - 1} fish.");
+                        
+                        if (_fish.DoubleHookExtension < 1)
+                        {
+                            ImUtf8.Text($"Double Hook for {_fish.DoubleHook} fish{(_fish.Points > 0 ? $" worth {_fish.Points * _fish.DoubleHook} points" : "")}");
+                            ImUtf8.Text($"Triple Hook for {2 * _fish.DoubleHook - 1} fish{(_fish.Points > 0 ? $" worth {_fish.Points * (2 * _fish.DoubleHook - 1)} points" : "")}");
+                        }
+                        else
+                        {
+                            ImUtf8.Text($"Double Hook for {_fish.DoubleHook}-{_fish.DoubleHookExtension} fish" +
+                                $"{(_fish.Points > 0 ? $" worth between {_fish.Points * _fish.DoubleHook} and {_fish.Points * _fish.DoubleHookExtension} points" : "")}");
+                            ImUtf8.Text($"Triple Hook for {2 * _fish.DoubleHook - 1}-{2 * _fish.DoubleHookExtension - 1} fish" +
+                                $"{(_fish.Points > 0 ? $" worth between {_fish.Points * (2 * _fish.DoubleHook - 1)} and {_fish.Points * (2 * _fish.DoubleHookExtension - 1)} points" : "")}");
+                        }
+
                         window._style.Pop();
                     }
                 }

--- a/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
@@ -124,7 +124,7 @@ public partial class FishTimerWindow
             // Some non-spectral ocean fish have weather restrictions, but this is not handled.
             var hasWeatherRestriction = fish.FishRestrictions.HasFlag(FishRestrictions.Weather) && !fish.OceanFish;
             if (GatherBuddy.Time.ServerTime < uptime.Start
-             && (!flags.HasFlag(FishRecord.Effects.FishEyes) || fish.IsLegendaryFish || hasWeatherRestriction || fish.Patch < Patch.Endwalker))
+             && (!flags.HasFlag(FishRecord.Effects.FishEyes) || fish.LegendaryFish || hasWeatherRestriction || fish.Patch < Patch.Endwalker))
                 Unavailable = true;
             if (fish.Snagging == Snagging.Required && !flags.HasFlag(FishRecord.Effects.Snagging))
                 Unavailable = true;

--- a/GatherBuddy/Gui/Interface.FishTab.ExtendedFish.cs
+++ b/GatherBuddy/Gui/Interface.FishTab.ExtendedFish.cs
@@ -74,8 +74,8 @@ public partial class Interface
         public ushort                    UptimePercent;
         public bool                      Unlocked = false;
         public bool                      Collectible;
-        public int                       DoubleHook;
-        public int                       DoubleHookExtension;
+        public int                       MultiHook;
+        public int                       MutliHookSecondValue;
         public int                       Points;
 
         public (ILocation, TimeInterval) Uptime
@@ -254,8 +254,8 @@ public partial class Interface
         {
             Data                = data;
             Collectible         = data.ItemData.IsCollectable;
-            DoubleHook          = data.MultiHook;
-            DoubleHookExtension = data.MultiHookExtension;
+            MultiHook          = data.MultiHook;
+            MutliHookSecondValue = data.MultiHookSecondValue;
             Points              = data.Points;
             Icon                = Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(data.ItemData.Icon));
             Territories         = string.Join("\n", data.FishingSpots.Select(f => f.Territory.Name).Distinct());

--- a/GatherBuddy/Gui/Interface.FishTab.ExtendedFish.cs
+++ b/GatherBuddy/Gui/Interface.FishTab.ExtendedFish.cs
@@ -75,6 +75,8 @@ public partial class Interface
         public bool                      Unlocked = false;
         public bool                      Collectible;
         public int                       DoubleHook;
+        public int                       DoubleHookExtension;
+        public int                       Points;
 
         public (ILocation, TimeInterval) Uptime
             => GatherBuddy.UptimeManager.BestLocation(Data);
@@ -250,11 +252,13 @@ public partial class Interface
 
         public ExtendedFish(Fish data)
         {
-            Data        = data;
-            Collectible = data.ItemData.IsCollectable;
-            DoubleHook  = data.MultiHook;
-            Icon        = Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(data.ItemData.Icon));
-            Territories = string.Join("\n", data.FishingSpots.Select(f => f.Territory.Name).Distinct());
+            Data                = data;
+            Collectible         = data.ItemData.IsCollectable;
+            DoubleHook          = data.MultiHook;
+            DoubleHookExtension = data.MultiHookExtension;
+            Points              = data.Points;
+            Icon                = Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(data.ItemData.Icon));
+            Territories         = string.Join("\n", data.FishingSpots.Select(f => f.Territory.Name).Distinct());
             if (!Territories.Contains("\n"))
                 Territories = '\0' + Territories;
             SpotNames = string.Join("\n", data.FishingSpots.Select(f => f.Name).Distinct());

--- a/GatherBuddy/Gui/Interface.FishTab.ExtendedFish.cs
+++ b/GatherBuddy/Gui/Interface.FishTab.ExtendedFish.cs
@@ -530,6 +530,17 @@ public partial class Interface
             ImGui.Button(fish.Patch);
         }
 
+        private static void PrintPoints(ExtendedFish fish)
+        {
+            using var color = new ImRaii.Color();
+            if (fish.Data.Points > 0)
+            {
+                color.Push(ImGuiCol.Button, 0xFF006400);
+                ImGui.Button($"Worth {fish.Data.Points} Points");
+                color.Pop();
+            }
+        }
+
         public void SetTooltip(Territory territory, Vector2 iconSize, Vector2 smallIconSize, Vector2 weatherIconSize, bool printName, bool standAlone = true)
         {
             using var tooltip = standAlone ? ImRaii.Tooltip() : ImRaii.IEndObject.Empty;
@@ -540,6 +551,7 @@ public partial class Interface
             PrintWeather(this, weatherIconSize);
             PrintBait(this, territory, iconSize, smallIconSize);
             PrintPredators(this, territory, iconSize);
+            PrintPoints(this);
             PrintFolklore(this);
         }
     }


### PR DESCRIPTION
- Fish Eyes only works on non-, non-ocean fishing, fish in areas added in the 2.X to 5.X patches.
  - Added Legendary Fish boolean. (Last 6 big fish added per patch)
- Added point values to CE fish with known, unchanging point values
- Added point values to SOME ocean fishing fish
- Added display on tooltip to relay point values.
  - There is currently a bug(?) where tooltips won't get displayed upon hover of the fish timer window if click through is enabled. NOT introduced by me. 
- Updated currently known (5/7/2025) data for fish for CE expansion 2