### PR TITLE
Suggestion Implementation

### DIFF
--- a/GatherBuddy/Config/Configuration.cs
+++ b/GatherBuddy/Config/Configuration.cs
@@ -48,6 +48,7 @@ public partial class Configuration : IPluginConfiguration
     public XivChatType      ChatTypeError          { get; set; } = XivChatType.ErrorMessage;
     public bool             AddIngameContextMenus  { get; set; } = true;
     public bool             StoreFishRecords       { get; set; } = true;
+    public bool             UseUnixTimeFishRecords { get; set; } = true;
     public bool             PrintClipboardMessages { get; set; } = true;
     public bool             HideClippy             { get; set; } = false;
     public bool             ShowStatusLine         { get; set; } = true;

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -273,6 +273,11 @@ public partial class Interface
                 "Store Fish Records on your computer. This is necessary for bite timings for the fish timer window.",
                 GatherBuddy.Config.StoreFishRecords, b => GatherBuddy.Config.StoreFishRecords = b);
 
+        public static void DrawShowLocalTimeInRecordsBox()
+            => DrawCheckbox("Use Local Time",
+                "When displaying timestamps in the Fish Records Tab, use local time instead of Unix time.",
+                GatherBuddy.Config.UseUnixTimeFishRecords, b => GatherBuddy.Config.UseUnixTimeFishRecords = b);
+
         public static void DrawFishTimerScale()
         {
             var value = GatherBuddy.Config.FishTimerScale / 1000f;
@@ -589,6 +594,7 @@ public partial class Interface
             if (ImGui.TreeNodeEx("Fish Timer"))
             {
                 ConfigFunctions.DrawKeepRecordsBox();
+                ConfigFunctions.DrawShowLocalTimeInRecordsBox();
                 ConfigFunctions.DrawFishTimerBox();
                 ConfigFunctions.DrawFishTimerEditBox();
                 ConfigFunctions.DrawFishTimerClickthroughBox();

--- a/GatherBuddy/Gui/Interface.RecordTab.cs
+++ b/GatherBuddy/Gui/Interface.RecordTab.cs
@@ -193,7 +193,13 @@ public partial class Interface
         private sealed class CastStartHeader : ColumnString<FishRecord>
         {
             public override string ToName(FishRecord record)
-                => (record.TimeStamp.Time / 1000).ToString();
+            {
+                if (!GatherBuddy.Config.UseUnixTimeFishRecords)
+                    return (record.TimeStamp.Time / 1000).ToString();
+                
+                var dateTime = DateTimeOffset.FromUnixTimeMilliseconds(record.TimeStamp.Time).ToLocalTime();
+                return dateTime.ToString("g");
+            }
 
             public override float Width
                 => 80 * ImGuiHelpers.GlobalScale;


### PR DESCRIPTION
Added config option (enabled by default) to display local time instead of Unix time for the timestamp column of fish records. 
Acknowledge that you can accomplish this by hovering over, but its just easier to read.