### PR TITLE
Fix bugs with assigning incorrect hooks in certain cases.

### DIFF
--- a/GatherBuddy/FishTimer/FishRecorder.Record.cs
+++ b/GatherBuddy/FishTimer/FishRecorder.Record.cs
@@ -187,7 +187,7 @@ public partial class FishRecorder
     {
         Timer.Stop();
         UpdateLure();
-        Record.SetTugHook(GatherBuddy.TugType.Bite, Record.Hook);
+        Record.SetTugHook(GatherBuddy.TugType.Bite, HookSet.None);
         Step |= CatchSteps.FishBit;
         if (LureTimer.ElapsedMilliseconds > 0)
             GatherBuddy.Log.Verbose(


### PR DESCRIPTION
When tug expires there is a brief moment where hooks are disabled, but can be clicked and recorded.
When reeling in, while hooks are disabled, they can still be clicked and recorded as a different hook.
After casting, hooks are briefly disabled, but can still be clicked and recorded if no later hook is pressed.