### PR TITLE
Oceanfishing update

### DIFF
--- a/GatherBuddy.GameData/Classes/Fish.CatchData.cs
+++ b/GatherBuddy.GameData/Classes/Fish.CatchData.cs
@@ -23,6 +23,7 @@ public partial class Fish
     public Fish?             SurfaceSlap     { get; internal set; }
     public string            Guide           { get; internal set; } = string.Empty;
     public OceanTime         OceanTime       { get; internal set; } = OceanTime.Always;
+    public OceanSpecies      OceanSpecies    { get; internal set; }
     public short             Points          { get; internal set; }
     public byte              MultiHookLower  { get; internal set; }
     public byte              MultiHookUpper  { get; internal set; }

--- a/GatherBuddy.GameData/Data/Fish/Data5.2.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data5.2.cs
@@ -41,28 +41,37 @@ public static partial class Fish
         data.Apply     (28937, Patch.EchoesOfAFallenStar) // Galadion Goby
             .Bait      (data, 29714)
             .Points    (10)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (28938, Patch.EchoesOfAFallenStar) // Galadion Chovy
             .Bait      (data, 29715)
             .Points    (11)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (28939, Patch.EchoesOfAFallenStar) // Rosy Bream
             .Bait      (data, 29715)
             .Points    (34)
+            .MultiHook (3,4)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (28940, Patch.EchoesOfAFallenStar) // Tripod Fish
             .Bait      (data, 29715)
+            .Points    (43)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
-            .Weather   (data, 2, 15, 16, 1);
+            .OceanType (OceanSpecies.Fugu)
+            .Weather   (data, 1, 2, 15, 16);
         data.Apply     (28941, Patch.EchoesOfAFallenStar) // Sunfly
             .Bait      (data, 29714)
             .Points    (10)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (28942, Patch.EchoesOfAFallenStar) // Tarnished Shark
             .Bait      (data, 29716)
             .Points    (34)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
-            .Weather   (data, 2, 3, 4, 7, 1);
+            .OceanType (OceanSpecies.Shark)
+            .Weather   (data, 1, 2, 3, 4, 7);
         data.Apply     (29673, Patch.EchoesOfAFallenStar) // Thinker's Coral
             .Bait      (data, 30136)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
@@ -71,102 +80,153 @@ public static partial class Fish
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29718, Patch.EchoesOfAFallenStar) // Tossed Dagger
             .Bait      (data, 29714)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .Points    (27)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Weather   (data, 1, 2, 3, 4, 15);
         data.Apply     (29719, Patch.EchoesOfAFallenStar) // Jasperhead
             .Bait      (data, 29715)
             .Points    (40)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
-            .Weather   (data, 2, 7, 8, 1);
+            .Weather   (data, 1, 2, 7, 8);
         data.Apply     (29720, Patch.EchoesOfAFallenStar) // Merlthor Lobster
             .Bait      (data, 29715)
+            .Points    (45)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29721, Patch.EchoesOfAFallenStar) // Heavenswimmer
             .Bait      (data, 29714)
+            .Points    (50)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29722, Patch.EchoesOfAFallenStar) // Ghoul Barracuda
             .Bait      (data, 29715)
             .Points    (10)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
-            .Weather   (data, 2, 3, 4, 1);
+            .Weather   (data, 1, 2, 3, 4);
         data.Apply     (29723, Patch.EchoesOfAFallenStar) // Leopard Eel
             .Bait      (data, 29716)
             .Points    (14)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
-            .Weather   (data, 2, 3, 4, 1);
+            .Weather   (data, 1, 2, 3, 4);
         data.Apply     (29724, Patch.EchoesOfAFallenStar) // Marine Bomb
             .Bait      (data, 29715)
             .Points    (27)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Fugu);
         data.Apply     (29725, Patch.EchoesOfAFallenStar) // Momora Mora
             .Bait      (data, 29716)
             .Points    (22)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply     (29726, Patch.EchoesOfAFallenStar) // Merlthor Butterfly
             .Bait      (data, 29714)
-            .Points    (22)
+            .Points    (51)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29727, Patch.EchoesOfAFallenStar) // Gladius
             .Mooch     (data, 29715, 29722)
             .Points    (49)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (29728, Patch.EchoesOfAFallenStar) // Rhotano Wahoo
             .Bait      (data, 29715)
+            .Points    (13)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
-            .Weather   (data, 2, 3, 4, 11, 1);
+            .Weather   (data, 1, 2, 3, 4, 11);
         data.Apply     (29729, Patch.EchoesOfAFallenStar) // Rhotano Sardine
             .Bait      (data, 29714)
+            .Points    (10)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29730, Patch.EchoesOfAFallenStar) // Deep Plaice
             .Bait      (data, 29715)
+            .Points    (15)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
-            .Weather   (data, 2, 3, 4, 1);
+            .Weather   (data, 1, 2, 3, 4);
         data.Apply     (29731, Patch.EchoesOfAFallenStar) // Crimson Monkfish
             .Bait      (data, 29716)
+            .Points    (32)
+            .MultiHook (3,4)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (29732, Patch.EchoesOfAFallenStar) // Lampfish
             .Bait      (data, 29714)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .Points    (47)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Fugu);
         data.Apply     (29733, Patch.EchoesOfAFallenStar) // Ogre Eel
             .Bait      (data, 29716)
+            .Points    (38)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
-            .Weather   (data, 2, 11, 14, 1);
+            .Weather   (data, 1, 2, 11, 26);
         data.Apply     (29734, Patch.EchoesOfAFallenStar) // Cyan Octopus
             .Bait      (data, 29715)
             .Points    (59)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .MultiHook (4)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Octopus);
         data.Apply     (29735, Patch.EchoesOfAFallenStar) // Chrome Hammerhead
             .Bait      (data, 29716)
-            .Bite      (data, HookSet.Powerful, BiteType.Legendary);
+            .Points    (32)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .OceanType (OceanSpecies.Shark);
         data.Apply     (29736, Patch.EchoesOfAFallenStar) // Floefish
             .Bait      (data, 29714)
+            .Points    (13)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
-            .Weather   (data, 2, 3, 4, 1);
+            .Weather   (data, 1, 2, 3, 4);
         data.Apply     (29737, Patch.EchoesOfAFallenStar) // Megasquid
             .Bait      (data, 29716)
+            .Points    (11)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (29738, Patch.EchoesOfAFallenStar) // Oschon's Stone
             .Bait      (data, 29716)
+            .Points    (11)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (29739, Patch.EchoesOfAFallenStar) // La Noscean Jelly
             .Bait      (data, 29714)
             .Points    (10)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (3,4)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Jellyfish);
         data.Apply     (29740, Patch.EchoesOfAFallenStar) // Shaggy Seadragon
             .Bait      (data, 29714)
             .Points    (35)
+            .MultiHook (4)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
-            .Weather   (data, 2, 5, 6, 1);
+            .OceanType (OceanSpecies.Seadragon)
+            .Weather   (data, 1, 2, 5, 6);
         data.Apply     (29741, Patch.EchoesOfAFallenStar) // Net Crawler
             .Bait      (data, 29715)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .Points    (36)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Crab);
         data.Apply     (29742, Patch.EchoesOfAFallenStar) // Dark Nautilus
             .Bait      (data, 29715)
+            .Points    (46)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (29743, Patch.EchoesOfAFallenStar) // Elder Dinichthys
             .Mooch     (data, 29714, 29718)
+            .Points    (52)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (29744, Patch.EchoesOfAFallenStar) // Drunkfish
             .Bait      (data, 29715)
+            .Points    (253)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Predators (data, 60, (28938, 3));
         data.Apply     (29745, Patch.EchoesOfAFallenStar) // Little Leviathan
@@ -176,152 +236,241 @@ public static partial class Fish
             .Predators (data, 60, (29727, 1));
         data.Apply     (29746, Patch.EchoesOfAFallenStar) // Sabaton
             .Bait      (data, 29715)
+            .Points    (204)
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
             .Predators (data, 60, (29731, 2));
         data.Apply     (29747, Patch.EchoesOfAFallenStar) // Shooting Star
             .Bait      (data, 29714)
+            .Points    (226)
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
             .Predators (data, 60, (29743, 1));
         data.Apply     (29748, Patch.EchoesOfAFallenStar) // Hammerclaw
             .Bait      (data, 29715)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .Points    (69)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29749, Patch.EchoesOfAFallenStar) // Heavenskey
             .Bait      (data, 29714)
             .Points    (67)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29750, Patch.EchoesOfAFallenStar) // Ghost Shark
             .Bait      (data, 29716)
             .Points    (78)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .MultiHook (4)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Shark)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29751, Patch.EchoesOfAFallenStar) // Quicksilver Blade
             .Bait      (data, 29716)
             .Points    (213)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Shark)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (29752, Patch.EchoesOfAFallenStar) // Navigator's Print
             .Bait      (data, 29715)
             .Points    (71)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29753, Patch.EchoesOfAFallenStar) // Casket Oyster
             .Bait      (data, 29714)
             .Points    (222)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Ocean     (OceanTime.Day);
         data.Apply     (29754, Patch.EchoesOfAFallenStar) // Fishmonger
             .Bait      (data, 29716)
             .Points    (78)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29755, Patch.EchoesOfAFallenStar) // Mythril Sovereign
             .Bait      (data, 29715)
             .Points    (196)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Ocean     (OceanTime.Day);
         data.Apply     (29756, Patch.EchoesOfAFallenStar) // Nimble Dancer
             .Bait      (data, 29714)
             .Points    (444)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Ocean     (OceanTime.Day);
         data.Apply     (29757, Patch.EchoesOfAFallenStar) // Sea Nettle
             .Bait      (data, 29714)
             .Points    (156)
+            .MultiHook (4)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Jellyfish)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (29758, Patch.EchoesOfAFallenStar) // Great Grandmarlin
             .Mooch     (data, 29714, 29761)
             .Points    (127)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29759, Patch.EchoesOfAFallenStar) // Shipwreck's Sail
             .Bait      (data, 29716)
             .Points    (59)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29760, Patch.EchoesOfAFallenStar) // Azeyma's Sleeve
             .Bait      (data, 29715)
             .Points    (69)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29761, Patch.EchoesOfAFallenStar) // Hi-aetherlouse
             .Bait      (data, 29714)
             .Points    (65)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29762, Patch.EchoesOfAFallenStar) // Floating Saucer
             .Bait      (data, 29715)
+            .Points    (222)
+            .MultiHook (4)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Jellyfish)
             .Ocean     (OceanTime.Night);
         data.Apply     (29763, Patch.EchoesOfAFallenStar) // Aetheric Seadragon
             .Mooch     (data, 29714, 29761)
             .Points    (245)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Seadragon)
             .Ocean     (OceanTime.Night);
         data.Apply     (29764, Patch.EchoesOfAFallenStar) // Coral Seadragon
             .Bait      (data, 29714)
+            .Points    (189)
+            .MultiHook (4)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Seadragon)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (29765, Patch.EchoesOfAFallenStar) // Roguesaurus
             .Mooch     (data, 29714, 29761)
-            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Points    (345)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (29766, Patch.EchoesOfAFallenStar) // Merman's Mane
             .Bait      (data, 29715)
             .Points    (94)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .MultiHook (4)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Octopus)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29767, Patch.EchoesOfAFallenStar) // Sweeper
             .Bait      (data, 29716)
+            .Points    (216)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Shark)
             .Ocean     (OceanTime.Day);
         data.Apply     (29768, Patch.EchoesOfAFallenStar) // Silencer
             .Bait      (data, 29714)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .Points    (89)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Fugu)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29769, Patch.EchoesOfAFallenStar) // Deep-sea Eel
             .Bait      (data, 29716)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .Points    (81)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29770, Patch.EchoesOfAFallenStar) // Executioner
             .Bait      (data, 29716)
+            .Points    (216)
+            .MultiHook (4)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .OceanType (OceanSpecies.Shark)
             .Ocean     (OceanTime.Day);
         data.Apply     (29771, Patch.EchoesOfAFallenStar) // Wild Urchin
             .Bait      (data, 29714)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .Points    (79)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29772, Patch.EchoesOfAFallenStar) // True Barramundi
             .Bait      (data, 29715)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .Points    (95)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29773, Patch.EchoesOfAFallenStar) // Mopbeard
             .Bait      (data, 29715)
+            .Points    (198)
+            .MultiHook (4)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Octopus)
             .Ocean     (OceanTime.Night);
         data.Apply     (29774, Patch.EchoesOfAFallenStar) // Slipsnail
             .Bait      (data, 29714)
+            .Points    (246)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Ocean     (OceanTime.Night);
         data.Apply     (29775, Patch.EchoesOfAFallenStar) // Aronnax
             .Bait      (data, 29715)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .Points    (95)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29776, Patch.EchoesOfAFallenStar) // Coccosteus
             .Bait      (data, 29716)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .Points    (79)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29777, Patch.EchoesOfAFallenStar) // Bartholomew the Chopper
             .Bait      (data, 29714)
+            .Points    (221)
+            .MultiHook (4)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Crab)
             .Ocean     (OceanTime.Night);
         data.Apply     (29778, Patch.EchoesOfAFallenStar) // Prowler
             .Bait      (data, 29714)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .Points    (79)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29779, Patch.EchoesOfAFallenStar) // Charlatan Survivor
             .Bait      (data, 29715)
             .Points    (69)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29780, Patch.EchoesOfAFallenStar) // Prodigal Son
             .Bait      (data, 29715)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .Points    (95)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29781, Patch.EchoesOfAFallenStar) // Gugrusaurus
             .Bait      (data, 29716)
-            .Bite      (data, HookSet.Powerful, BiteType.Legendary);
+            .Points    (79)
+            .MultiHook (3,4)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (29782, Patch.EchoesOfAFallenStar) // Funnel Shark
             .Bait      (data, 29716)
             .Points    (213)
+            .MultiHook (4)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .OceanType (OceanSpecies.Shark)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (29783, Patch.EchoesOfAFallenStar) // The Fallen One
             .Bait      (data, 29715)
+            .Points    (374)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (29784, Patch.EchoesOfAFallenStar) // Spectral Megalodon
@@ -343,7 +492,7 @@ public static partial class Fish
             .Bait      (data, 29716)
             .Points    (100)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
-            .Weather   (data, 2, 3, 4, 11, 14);
+            .Weather   (data, 2, 3, 4, 11, 26);
         data.Apply     (29788, Patch.EchoesOfAFallenStar) // Sothis
             .Bait      (data, 2603)
             .Points    (500)
@@ -358,11 +507,13 @@ public static partial class Fish
             .Predators (data, 15, (29758, 2));
         data.Apply     (29790, Patch.EchoesOfAFallenStar) // Stonescale
             .Bait      (data, 2591)
+            .Points    (500)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Ocean     (OceanTime.Sunset)
             .Predators (data, 15, (29769, 1), (29768, 1));
         data.Apply     (29791, Patch.EchoesOfAFallenStar) // Elasmosaurus
             .Bait      (data, 2619)
+            .Points    (500)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Ocean     (OceanTime.Day)
             .Predators (data, 15, (29781, 3));

--- a/GatherBuddy.GameData/Data/Fish/Data5.4.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data5.4.cs
@@ -51,37 +51,48 @@ public static partial class Fish
         data.Apply     (32055, Patch.FuturesRewritten) // Tortoiseshell Crab
             .Bait      (data, 29715)
             .Points    (10)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Crab);
         data.Apply     (32056, Patch.FuturesRewritten) // Lady's Cameo
             .Bait      (data, 29714)
-            .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Points    (15)
-            .Weather   (data, 2, 3, 4, 1);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Weather   (data, 1, 2, 3, 4);
         data.Apply     (32057, Patch.FuturesRewritten) // Metallic Boxfish
             .Bait      (data, 29714)
             .Points    (9)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Fugu);
         data.Apply     (32058, Patch.FuturesRewritten) // Goobbue Ray
             .Bait      (data, 29716)
             .Points    (33)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Manta);
         data.Apply     (32059, Patch.FuturesRewritten) // Watermoura
             .Bait      (data, 29715)
             .Points    (41)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
-            .Weather   (data, 2, 3, 4, 9, 1);
+            .Weather   (data, 1, 2, 3, 4, 9);
         data.Apply     (32060, Patch.FuturesRewritten) // King Cobrafish
             .Bait      (data, 29716)
-            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Points    (39)
-            .Weather   (data, 2, 9, 10, 1);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Weather   (data, 1, 2, 9, 10);
         data.Apply     (32061, Patch.FuturesRewritten) // Mamahi-mahi
             .Bait      (data, 29716)
             .Points    (58)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply     (32062, Patch.FuturesRewritten) // Lavandin Remora
             .Bait      (data, 29715)
             .Points    (52)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (32063, Patch.FuturesRewritten) // Spectral Butterfly
             .Bait      (data, 29714)
@@ -96,41 +107,58 @@ public static partial class Fish
         data.Apply     (32065, Patch.FuturesRewritten) // Titanshell Crab
             .Bait      (data, 29715)
             .Points    (84)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .MultiHook (4)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Crab)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32066, Patch.FuturesRewritten) // Mythril Boxfish
             .Bait      (data, 29714)
             .Points    (64)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (4)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Fugu)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32067, Patch.FuturesRewritten) // Mistbeard's Cup
-            .Bait      (data, 29715)
+            .Bait      (data, 27590)
             .Points    (84)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32068, Patch.FuturesRewritten) // Anomalocaris Saron
-            .Bait      (data, 29715)
+            .Bait      (data, 27590)
             .Points    (84)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32069, Patch.FuturesRewritten) // Flaming Eel
             .Bait      (data, 29715)
             .Points    (198)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (32070, Patch.FuturesRewritten) // Jetborne Manta
             .Bait      (data, 29716)
             .Points    (75)
-            .Bite      (data, HookSet.Powerful, BiteType.Legendary);
+            .MultiHook (4)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .OceanType (OceanSpecies.Manta)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32071, Patch.FuturesRewritten) // Devil's Sting
             .Bait      (data, 29715)
             .Points    (201)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Ocean     (OceanTime.Day);
         data.Apply     (32072, Patch.FuturesRewritten) // Callichthyid
             .Bait      (data, 29716)
             .Points    (178)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Ocean     (OceanTime.Day);
         data.Apply     (32073, Patch.FuturesRewritten) // Meandering Mora
             .Bait      (data, 29716)
             .Points    (283)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
             .Ocean     (OceanTime.Sunset);
         data.Apply     (32074, Patch.FuturesRewritten) // Hafgufa
@@ -142,37 +170,47 @@ public static partial class Fish
         data.Apply     (32075, Patch.FuturesRewritten) // Thaliak Crab
             .Bait      (data, 29714)
             .Points    (9)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Crab);
         data.Apply     (32076, Patch.FuturesRewritten) // Star of the Destroyer
             .Bait      (data, 29714)
             .Points    (14)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
-            .Weather   (data, 2, 3, 4, 1);
+            .Weather   (data, 1, 2, 3, 4);
         data.Apply     (32077, Patch.FuturesRewritten) // True Scad
             .Bait      (data, 29715)
             .Points    (8)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (32078, Patch.FuturesRewritten) // Blooded Wrasse
             .Bait      (data, 29716)
             .Points    (35)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
-            .Weather   (data, 2, 3, 4, 7, 1);
+            .Weather   (data, 1, 2, 3, 4, 7);
         data.Apply     (32079, Patch.FuturesRewritten) // Bloodpolish Crab
             .Bait      (data, 29714)
             .Points    (28)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (4)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Crab);
         data.Apply     (32080, Patch.FuturesRewritten) // Blue Stitcher
             .Bait      (data, 29715)
             .Points    (30)
+            .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
-            .Weather   (data, 2, 7, 8, 1);
+            .Weather   (data, 1, 2, 7, 8);
         data.Apply     (32081, Patch.FuturesRewritten) // Bloodfresh Tuna
             .Bait      (data, 29716)
             .Points    (43)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (32082, Patch.FuturesRewritten) // Sunken Mask
             .Bait      (data, 29714)
             .Points    (49)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply     (32083, Patch.FuturesRewritten) // Spectral Eel
             .Bait      (data, 29715)
@@ -187,42 +225,61 @@ public static partial class Fish
         data.Apply     (32085, Patch.FuturesRewritten) // Oracular Crab
             .Bait      (data, 29714)
             .Points    (102)
+            .MultiHook (4)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Crab)
             .Ocean     (OceanTime.Day);
         data.Apply     (32086, Patch.FuturesRewritten) // Dravanian Bream
             .Bait      (data, 29715)
             .Points    (77)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32087, Patch.FuturesRewritten) // Skaldminni
             .Bait      (data, 29715)
             .Points    (102)
+            .MultiHook (4)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Manta)
             .Ocean     (OceanTime.Night);
         data.Apply     (32088, Patch.FuturesRewritten) // Serrated Clam
             .Bait      (data, 29714)
             .Points    (74)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32089, Patch.FuturesRewritten) // Beatific Vision
-            .Bait      (data, 29715)
+            .Bait      (data, 2587)
             .Points    (77)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .MultiHook (4)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32090, Patch.FuturesRewritten) // Exterminator
             .Bait      (data, 29714)
             .Points    (255)
+            .MultiHook (4)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Crab)
             .Ocean     (OceanTime.Day);
         data.Apply     (32091, Patch.FuturesRewritten) // Gory Tuna
             .Bait      (data, 29716)
             .Points    (92)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32092, Patch.FuturesRewritten) // Ticinepomis
             .Bait      (data, 29716)
             .Points    (92)
-            .Bite      (data, HookSet.Powerful, BiteType.Legendary);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32093, Patch.FuturesRewritten) // Quartz Hammerhead
             .Bait      (data, 29716)
             .Points    (460)
-            .Bite      (data, HookSet.Powerful, BiteType.Legendary);
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .OceanType (OceanSpecies.Shark)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32094, Patch.FuturesRewritten) // Seafaring Toad
             .Bait      (data, 2587)
             .Points    (500)
@@ -231,71 +288,121 @@ public static partial class Fish
             .Predators (data, 15, (32089, 3));
         data.Apply     (32095, Patch.FuturesRewritten) // Crow Puffer
             .Bait      (data, 29714)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .Points    (10)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Fugu);
         data.Apply     (32096, Patch.FuturesRewritten) // Rothlyt Kelp
             .Bait      (data, 29714)
+            .Points    (10)
+            .MultiHook (3,4)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (32097, Patch.FuturesRewritten) // Living Lantern
             .Bait      (data, 29715)
+            .Points    (13)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
-            .Weather   (data, 2, 3, 4, 1);
+            .OceanType (OceanSpecies.Jellyfish)
+            .Weather   (data, 1, 2, 3, 4);
         data.Apply     (32098, Patch.FuturesRewritten) // Honeycomb Fish
             .Bait      (data, 29714)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .Points    (29)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Fugu);
         data.Apply     (32099, Patch.FuturesRewritten) // Godsbed
             .Bait      (data, 29716)
+            .Points    (29)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
-            .Weather   (data, 2, 9, 10, 1);
+            .Weather   (data, 1, 2, 9, 10);
         data.Apply     (32100, Patch.FuturesRewritten) // Lansquenet
             .Bait      (data, 29716)
+            .Points    (36)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
-            .Weather   (data, 2, 3, 4, 9, 1);
+            .Weather   (data, 1, 2, 3, 4, 9);
         data.Apply     (32101, Patch.FuturesRewritten) // Thavnairian Shark
             .Bait      (data, 29715)
-            .Bite      (data, HookSet.Powerful, BiteType.Legendary);
+            .Points    (44)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .OceanType (OceanSpecies.Shark);
         data.Apply     (32102, Patch.FuturesRewritten) // Nephrite Eel
             .Bait      (data, 29715)
+            .Points    (44)
+            .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (32103, Patch.FuturesRewritten) // Spectresaur
             .Bait      (data, 29716)
+            .Points    (100)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Weather   (data, 2, 3, 4, 9, 10);
         data.Apply     (32104, Patch.FuturesRewritten) // Ginkgo Fin
             .Bait      (data, 29714)
+            .Points    (238)
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
             .Predators (data, 60, (32096, 3));
         data.Apply     (32105, Patch.FuturesRewritten) // Garum Jug
-            .Bait      (data, 29715)
+            .Bait      (data, 29714)
+            .Points    (107)
+            .MultiHook (4)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Fugu)
             .Ocean     (OceanTime.Day, OceanTime.Night);
         data.Apply     (32106, Patch.FuturesRewritten) // Smooth Jaguar
             .Bait      (data, 29716)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .Points    (70)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32107, Patch.FuturesRewritten) // Rothlyt Mussel
             .Bait      (data, 29714)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .Points    (72)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32108, Patch.FuturesRewritten) // Levi Elver
             .Bait      (data, 29715)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .Points    (75)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32109, Patch.FuturesRewritten) // Pearl Bombfish
             .Bait      (data, 29715)
+            .Points    (237)
+            .MultiHook (4)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Fugu)
             .Ocean     (OceanTime.Day, OceanTime.Night);
         data.Apply     (32110, Patch.FuturesRewritten) // Trollfish
             .Mooch     (data, 29714, 32107)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .Points    (202)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32111, Patch.FuturesRewritten) // Panoptes
             .Bait      (data, 29716)
+            .Points    (125)
+            .MultiHook (4)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Manta)
             .Ocean     (OceanTime.Day);
         data.Apply     (32112, Patch.FuturesRewritten) // Crepe Sole
             .Bait      (data, 29714)
-            .Bite      (data, HookSet.Precise, BiteType.Weak);
+            .Points    (72)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32113, Patch.FuturesRewritten) // Knifejaw
             .Bait      (data, 29715)
-            .Bite      (data, HookSet.Powerful, BiteType.Strong);
+            .Points    (465)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply     (32114, Patch.FuturesRewritten) // Placodus
             .Mooch     (data, 29714, 32107)
+            .Points    (500)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Ocean     (OceanTime.Sunset)
             .Predators (data, 45, (32110, 1));

--- a/GatherBuddy.GameData/Data/Fish/Data6.4.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data6.4.cs
@@ -55,435 +55,477 @@ public static partial class Fish
             .Time(960, 1140)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(40521, Patch.TheDarkThrone) // Pink Shrimp
-            .Bait(data, 29715)
-            .Points(31)
-            .MultiHook(3)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29715)
+            .Points    (31)
+            .MultiHook (3)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Shrimp);
         data.Apply(40522, Patch.TheDarkThrone) // Sirensong Mussel
-            .Bait(data, 29714)
-            .Points(11)
-            .MultiHook(3)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (11)
+            .MultiHook (3)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Shellfish);
         data.Apply(40523, Patch.TheDarkThrone) // Arrowhead
-            .Bait(data, 29715)
-            .Points(10)
-            .MultiHook(3)
-            .Bite(data, HookSet.Powerful, BiteType.Strong);
+            .Bait      (data, 29715)
+            .Points    (10)
+            .MultiHook (3)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Squid);
         data.Apply(40524, Patch.TheDarkThrone) // Deepshade Sardine
-            .Bait(data, 29716)
-            .Points(15)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Weather(data, 2, 3, 4, 1);
+            .Bait      (data, 29716)
+            .Points    (15)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Weather   (data, 1, 2, 3, 4);
         data.Apply(40525, Patch.TheDarkThrone) // Sirensong Mullet
-            .Bait(data, 29715)
-            .Points(42)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Weather(data, 2, 3, 4, 7, 1);
+            .Bait      (data, 29715)
+            .Points    (42)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Weather   (data, 1, 2, 3, 4, 7);
         data.Apply(40526, Patch.TheDarkThrone) // Selkie Puffer
-            .Bait(data, 29714)
-            .Points(38)
-            .MultiHook(4)
-            .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Weather(data, 2, 7, 10, 1);
+            .Bait      (data, 29714)
+            .Points    (38)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Weather   (data, 1, 2, 7, 10);
         data.Apply(40527, Patch.TheDarkThrone) // Poet's Pipe
-            .Bait(data, 29714)
-            .Points(56)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (56)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply(40528, Patch.TheDarkThrone) // Marine Matanga
-            .Bait(data, 29716)
-            .Points(47)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary);
+            .Bait      (data, 29716)
+            .Points    (47)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply(40529, Patch.TheDarkThrone) // Spectral Coelacanth
-            .Bait(data, 29716)
-            .Points(100)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Weather(data, 2, 3, 4, 7, 10);
+            .Bait      (data, 29716)
+            .Points    (100)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Weather   (data, 2, 3, 4, 7, 10);
         data.Apply(40530, Patch.TheDarkThrone) // Dusk Shark
-            .Bait(data, 29716)
-            .Points(263)
-            .Predators (data, 60, (40527, 2))
-            .Bite(data, HookSet.Powerful, BiteType.Legendary);
+            .Bait      (data, 29716)
+            .Points    (263)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Predators (data, 60, (40527, 2));
         data.Apply(40531, Patch.TheDarkThrone) // Mermaid Scale
-            .Bait(data, 29714)
-            .Points(51)
-            .MultiHook(4)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (51)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Shellfish)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40532, Patch.TheDarkThrone) // Broadhead
-            .Bait(data, 29716)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Ocean(OceanTime.Day, OceanTime.Sunset);
+            .Bait      (data, 29716)
+            .Points    (68)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Squid)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset);
         data.Apply(40533, Patch.TheDarkThrone) // Vivid Pink Shrimp
-            .Bait(data, 29715)
-            .Points(144)
-            .MultiHook(4)
-            .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Ocean(OceanTime.Night);
+            .Bait      (data, 29715)
+            .Points    (144)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Shrimp)
+            .Ocean     (OceanTime.Night);
         data.Apply(40534, Patch.TheDarkThrone) // Sunken Coelacanth
-            .Bait(data, 29716)
-            .Points(51)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary);
+            .Bait      (data, 29716)
+            .Points    (51)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40535, Patch.TheDarkThrone) // Siren's Sigh
-            .Bait(data, 29714)
-            .Points(101)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (101)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40536, Patch.TheDarkThrone) // Black-jawed Helicoprion
-            .Bait(data, 29716)
-            .Points(102)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Ocean(OceanTime.Night);
+            .Bait      (data, 29716)
+            .Points    (102)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean     (OceanTime.Night);
         data.Apply(40537, Patch.TheDarkThrone) // Impostopus
-            .Bait(data, 29715)
-            .Points(144)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
-        data.Apply(40538, Patch.TheDarkThrone) // Jade Shrimp
-            .Bait(data, 29715)
-            .Points(72)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29715)
+            .Points    (144)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
+        data.Apply(40538, Patch.TheDarkThrone) // Jade Mantis Shrimp
+            .Bait      (data, 29715)
+            .Points    (72)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40539, Patch.TheDarkThrone) // Nymeia's Wheel
-            .Bait(data, 29715)
-            .Points(289)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Ocean(OceanTime.Sunset);
+            .Bait      (data, 29715)
+            .Points    (289)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Sunset);
         data.Apply(40540, Patch.TheDarkThrone) // Taniwha
-            .Bait(data, 36593)
-            .Points(500)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Predators (data, 15, (40534, 3))
-            .Ocean(OceanTime.Day);
+            .Bait      (data, 36593)
+            .Points    (500)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean     (OceanTime.Day)
+            .Predators (data, 15, (40534, 3));
         data.Apply(40541, Patch.TheDarkThrone) // Ruby Herring
-            .Bait(data, 29715)
-            .Points(14)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Weather(data, 2, 3, 4, 1);
-        data.Apply(40542, Patch.TheDarkThrone) // Whirpool Turban
-            .Bait(data, 29714)
-            .Points(10)
-            .MultiHook(3)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29715)
+            .Points    (14)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Weather   (data, 1, 2, 3, 4);
+        data.Apply(40542, Patch.TheDarkThrone) // Whirlpool Turban
+            .Bait      (data, 29714)
+            .Points    (10)
+            .MultiHook (3)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Shellfish);
         data.Apply(40543, Patch.TheDarkThrone) // Leopard Prawn
-            .Bait(data, 29714)
-            .Points(10)
-            .MultiHook(3)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (10)
+            .MultiHook (3)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Shrimp);
         data.Apply(40544, Patch.TheDarkThrone) // Spear Squid
-            .Bait(data, 29716)
-            .Points(26)
-            .MultiHook(3)
-            .Bite(data, HookSet.Powerful, BiteType.Strong);
+            .Bait      (data, 29716)
+            .Points    (26)
+            .MultiHook (3)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Squid);
         data.Apply(40545, Patch.TheDarkThrone) // Floating Lantern
-            .Bait(data, 29716)
-            .Points(37)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Weather(data, 2, 3, 4, 7, 1);
+            .Bait      (data, 29716)
+            .Points    (37)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Weather   (data, 1, 2, 3, 4, 7);
         data.Apply(40546, Patch.TheDarkThrone) // Rubescent Tatsunoko
-            .Bait(data, 29715)
-            .Points(33)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Weather(data, 2, 7, 8, 1);
+            .Bait      (data, 29715)
+            .Points    (33)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Weather   (data, 1, 2, 7, 8);
         data.Apply(40547, Patch.TheDarkThrone) // Hatatate
-            .Bait(data, 29714)
-            .Points(53)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (53)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply(40548, Patch.TheDarkThrone) // Silent Shark
-            .Mooch(data, 29714, 40543)
-            .Points(35)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary);
+            .Mooch     (data, 29714, 40543)
+            .Points    (35)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply(40549, Patch.TheDarkThrone) // Spectral Wrasse
-            .Bait(data, 29715)
-            .Points(100)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Weather(data, 2, 3, 4, 7, 8);
+            .Bait      (data, 29715)
+            .Points    (100)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Weather   (data, 2, 3, 4, 7, 8);
         data.Apply(40550, Patch.TheDarkThrone) // Mizuhiki
-            .Bait(data, 29714)
-            .Points(263)
-            .Predators (data, 60, (40548, 2))
-            .Bite(data, HookSet.Precise, BiteType.Legendary);
+            .Bait      (data, 29714)
+            .Points    (263)
+            .Bite      (data, HookSet.Precise, BiteType.Legendary)
+            .Predators (data, 60, (40548, 2));
         data.Apply(40551, Patch.TheDarkThrone) // Snapping Koban
-            .Bait(data, 29715)
-            .Points(62)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong);
+            .Bait      (data, 29715)
+            .Points    (62)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40552, Patch.TheDarkThrone) // Silkweft Prawn
-            .Bait(data, 29714)
-            .Points(58)
-            .MultiHook(4)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (58)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Shrimp)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40553, Patch.TheDarkThrone) // Stingfin Trevally
-            .Bait(data, 29715)
-            .Points(191)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Ocean(OceanTime.Day);
+            .Bait      (data, 29715)
+            .Points    (191)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day);
         data.Apply(40554, Patch.TheDarkThrone) // Swordtip Squid
-            .Bait(data, 29716)
-            .Points(115)
-            .MultiHook(4)
-            .Bite(data, HookSet.Powerful, BiteType.Strong);
+            .Bait      (data, 29716)
+            .Points    (115)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Squid)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40555, Patch.TheDarkThrone) // Mailfish
-            .Bait(data, 29714)
-            .Points(198)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Ocean(OceanTime.Sunset);
+            .Bait      (data, 29714)
+            .Points    (198)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Sunset);
         data.Apply(40556, Patch.TheDarkThrone) // Idaten's Bolt
-            .Bait(data, 29715)
-            .Points(62)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29715)
+            .Points    (62)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40557, Patch.TheDarkThrone) // Maelstrom Turban
-            .Bait(data, 29714)
-            .Points(83)
-            .MultiHook(4)
-            .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Ocean(OceanTime.Day, OceanTime.Sunset);
+            .Bait      (data, 29714)
+            .Points    (83)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Shellfish)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset);
         data.Apply(40558, Patch.TheDarkThrone) // Shoshitsuki
-            .Bait(data, 29716)
-            .Points(92)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary);
+            .Bait      (data, 29716)
+            .Points    (92)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40559, Patch.TheDarkThrone) // Spadefish
-            .Bait(data, 29715)
-            .Points(191)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Ocean(OceanTime.Sunset);
+            .Bait      (data, 29715)
+            .Points    (191)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Sunset);
         data.Apply(40560, Patch.TheDarkThrone) // Glass Dragon
-            .Mooch(data, 29715, 40551)
-            .Points(500)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Predators (data, 45, (40558, 2))
-            .Ocean(OceanTime.Night);
+            .Mooch     (data, 29715, 40551)
+            .Points    (500)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean     (OceanTime.Night)
+            .Predators (data, 45, (40558, 2));
         data.Apply(40561, Patch.TheDarkThrone) // Crimson Kelp
-            .Bait(data, 29714)
-            .Points(11)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (11)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply(40562, Patch.TheDarkThrone) // Reef Squid
-            .Bait(data, 29715)
-            .Points(10)
-            .MultiHook(3)
-            .Bite(data, HookSet.Powerful, BiteType.Strong);
+            .Bait      (data, 29715)
+            .Points    (10)
+            .MultiHook (3)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Squid);
         data.Apply(40563, Patch.TheDarkThrone) // Pinebark Flounder
-            .Bait(data, 29714)
-            .Points(15)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Weather(data, 2, 3, 4, 6, 9, 1);
+            .Bait      (data, 29714)
+            .Points    (15)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Weather   (data, 1, 2, 3, 4, 6, 9);
         data.Apply(40564, Patch.TheDarkThrone) // Mantle Moray
-            .Bait(data, 29715)
-            .Points(41)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Weather(data, 2, 3, 4, 5, 6, 1);
+            .Bait      (data, 29715)
+            .Points    (41)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Weather   (data, 1, 2, 3, 4, 5, 6);
         data.Apply(40565, Patch.TheDarkThrone) // Shisui Goby
-            .Bait(data, 29714)
-            .Points(57)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (57)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply(40566, Patch.TheDarkThrone) // Sanbaso
-            .Bait(data, 29716)
-            .Points(38)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Weather(data, 2, 5, 6, 9, 1);
+            .Bait      (data, 29716)
+            .Points    (38)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Weather   (data, 1, 2, 5, 6, 9);
         data.Apply(40567, Patch.TheDarkThrone) // Barded Lobster
-            .Bait(data, 29714)
-            .Points(33)
-            .MultiHook(3)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (33)
+            .MultiHook (3)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Shrimp);
         data.Apply(40568, Patch.TheDarkThrone) // Violet Sentry
-            .Bait(data, 29716)
-            .Points(55)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary);
+            .Bait      (data, 29716)
+            .Points    (55)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply(40569, Patch.TheDarkThrone) // Spectral Snake Eel
-            .Bait(data, 29715)
-            .Points(100)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Weather(data, 2, 3, 4, 5, 6, 9);
+            .Bait      (data, 29715)
+            .Points    (100)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Weather   (data, 2, 3, 4, 5, 6, 9);
         data.Apply(40570, Patch.TheDarkThrone) // Heavensent Shark
-            .Bait(data, 29715)
-            .Points(227)
-            .Predators (data, 60, (40561, 3))
-            .Bite(data, HookSet.Powerful, BiteType.Legendary);
+            .Bait      (data, 29715)
+            .Points    (227)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Predators (data, 60, (40561, 3));
         data.Apply(40571, Patch.TheDarkThrone) // Fleeting Squid
-            .Bait(data, 29715)
-            .Points(81)
-            .MultiHook(4)
-            .Bite(data, HookSet.Powerful, BiteType.Strong);
+            .Bait      (data, 29715)
+            .Points    (81)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Squid)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40572, Patch.TheDarkThrone) // Bowbarb Lobster
-            .Bait(data, 29714)
-            .Points(83)
-            .MultiHook(4)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (83)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Shrimp)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40573, Patch.TheDarkThrone) // Pitch Pickle
-            .Bait(data, 29714)
-            .Points(218)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Ocean(OceanTime.Day);
+            .Bait      (data, 29714)
+            .Points    (218)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day);
         data.Apply(40574, Patch.TheDarkThrone) // Senbei Octopus
-            .Bait(data, 29714)
-            .Points(83)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (83)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40575, Patch.TheDarkThrone) // Tentacle Thresher
-            .Bait(data, 29716)
-            .Points(76)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong);
+            .Bait      (data, 29716)
+            .Points    (76)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40576, Patch.TheDarkThrone) // Bekko Rockhugger
-            .Bait(data, 29715)
-            .Points(187)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Ocean(OceanTime.Night);
+            .Bait      (data, 29715)
+            .Points    (187)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Night);
         data.Apply(40577, Patch.TheDarkThrone) // Yellow Iris
-            .Bait(data, 29714)
-            .Points(218)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Ocean(OceanTime.Day);
+            .Bait      (data, 29714)
+            .Points    (218)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day);
         data.Apply(40578, Patch.TheDarkThrone) // Crimson Sentry
-            .Bait(data, 29716)
-            .Points(178)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Ocean(OceanTime.Night);
+            .Bait      (data, 29716)
+            .Points    (178)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean     (OceanTime.Night);
         data.Apply(40579, Patch.TheDarkThrone) // Flying Squid
-            .Bait(data, 29716)
-            .Points(126)
-            .MultiHook(4)
-            .Bite(data, HookSet.Powerful, BiteType.Strong);
+            .Bait      (data, 29716)
+            .Points    (126)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .OceanType (OceanSpecies.Squid)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40580, Patch.TheDarkThrone) // Hells' Claw
-            .Bait(data, 27590)
-            .Points(500)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Predators (data, 15, (40571, 2), (40579, 1))
-            .Ocean(OceanTime.Sunset);
+            .Bait      (data, 27590)
+            .Points    (500)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean     (OceanTime.Sunset)
+            .Predators (data, 15, (40571, 2), (40579, 1));
         data.Apply(40581, Patch.TheDarkThrone) // Catching Carp
-            .Bait(data, 29714)
-            .Points(10)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (10)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply(40582, Patch.TheDarkThrone) // Garlean Bluegill
-            .Bait(data, 29715)
-            .Points(14)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Weather(data, 2, 3, 4, 1);
+            .Bait      (data, 29715)
+            .Points    (14)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Weather   (data, 1, 2, 3, 4);
         data.Apply(40583, Patch.TheDarkThrone) // Yanxian Softshell
-            .Bait(data, 29715)
-            .Points(10)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong);
+            .Bait      (data, 29715)
+            .Points    (10)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply(40584, Patch.TheDarkThrone) // Princess Salmon
-            .Bait(data, 29714)
-            .Points(37)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Weather(data, 2, 7, 8, 1);
+            .Bait      (data, 29714)
+            .Points    (37)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Weather   (data, 1, 2, 7, 8);
         data.Apply(40585, Patch.TheDarkThrone) // Calligraph
-            .Bait(data, 29716)
-            .Points(40)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Weather(data, 2, 3, 4, 7, 1);
+            .Bait      (data, 29716)
+            .Points    (40)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Weather   (data, 1, 2, 3, 4, 7);
         data.Apply(40586, Patch.TheDarkThrone) // Singular Shrimp
-            .Bait(data, 29714)
-            .Points(31)
-            .MultiHook(3)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (31)
+            .MultiHook (3)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Shrimp);
         data.Apply(40587, Patch.TheDarkThrone) // Brocade Carp
-            .Bait(data, 29715)
-            .Points(52)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong);
+            .Bait      (data, 29715)
+            .Points    (52)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply(40588, Patch.TheDarkThrone) // Yanxian Sturgeon
-            .Bait(data, 29716)
-            .Points(49)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary);
+            .Bait      (data, 29716)
+            .Points    (49)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary);
         data.Apply(40589, Patch.TheDarkThrone) // Spectral Kotsu Zetsu
-            .Bait(data, 29715)
-            .Points(100)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Weather(data, 2, 3, 4, 7, 8);
+            .Bait      (data, 29715)
+            .Points    (100)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Weather   (data, 2, 3, 4, 7, 8);
         data.Apply(40590, Patch.TheDarkThrone) // Fishy Shark
-            .Bait(data, 29716)
-            .Points(223)
-            .Predators (data, 60, (40581, 3))
-            .Bite(data, HookSet.Powerful, BiteType.Legendary);
+            .Bait      (data, 29716)
+            .Points    (223)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Predators (data, 60, (40581, 3));
         data.Apply(40591, Patch.TheDarkThrone) // Gensui Shrimp
-            .Bait(data, 29714)
-            .Points(85)
-            .MultiHook(4)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (85)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Shrimp)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40592, Patch.TheDarkThrone) // Yato-no-kami
-            .Bait(data, 29716)
-            .Points(79)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong);
+            .Bait      (data, 29716)
+            .Points    (79)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40593, Patch.TheDarkThrone) // Heron's Eel
-            .Bait(data, 29716)
-            .Points(79)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong);
+            .Bait      (data, 29716)
+            .Points    (79)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40594, Patch.TheDarkThrone) // Crowshadow Mussel
-            .Bait(data, 29714)
-            .Points(85)
-            .MultiHook(4)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (85)
+            .MultiHook (4)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .OceanType (OceanSpecies.Shellfish)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40595, Patch.TheDarkThrone) // Yanxian Goby
-            .Bait(data, 29714)
-            .Points(85)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak);
+            .Bait      (data, 29714)
+            .Points    (85)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(40596, Patch.TheDarkThrone) // Iridescent Trout
-            .Bait(data, 29715)
-            .Points(184)
-            .MultiHook(2)
-            .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Ocean(OceanTime.Sunset);
+            .Bait      (data, 29715)
+            .Points    (184)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Precise, BiteType.Weak)
+            .Ocean     (OceanTime.Sunset);
         data.Apply(40597, Patch.TheDarkThrone) // Un-Namazu
-            .Bait(data, 29715)
-            .Points(209)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Ocean(OceanTime.Night);
+            .Bait      (data, 29715)
+            .Points    (209)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Night);
         data.Apply(40598, Patch.TheDarkThrone) // Gakugyo
-            .Bait(data, 29716)
-            .Points(185)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Ocean(OceanTime.Night);
+            .Bait      (data, 29716)
+            .Points    (185)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean     (OceanTime.Night);
         data.Apply(40599, Patch.TheDarkThrone) // Ginrin Goshiki
-            .Bait(data, 29715)
-            .Points(209)
-            .MultiHook(2)
-            .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Ocean(OceanTime.Sunset);
+            .Bait      (data, 29715)
+            .Points    (209)
+            .MultiHook (2)
+            .Bite      (data, HookSet.Powerful, BiteType.Strong)
+            .Ocean     (OceanTime.Sunset);
         data.Apply(40600, Patch.TheDarkThrone) // Jewel of Plum Spring
-            .Bait(data, 12704)
-            .Points(500)
-            .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Predators (data, 15, (40595, 2), (40591, 1))
-            .Ocean(OceanTime.Day);
+            .Bait      (data, 12704)
+            .Points    (500)
+            .Bite      (data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean     (OceanTime.Day)
+            .Predators (data, 15, (40595, 2), (40591, 1));
     }
     // @formatter:on
 }

--- a/GatherBuddy.GameData/Data/Fish/DataBase.cs
+++ b/GatherBuddy.GameData/Data/Fish/DataBase.cs
@@ -340,6 +340,15 @@ public static partial class Fish
         return fish;
     }
 
+    private static Classes.Fish? OceanType(this Classes.Fish? fish, OceanSpecies value)
+    {
+        if (fish == null)
+            return null;
+        
+        fish.OceanSpecies = value;
+        return fish;
+    }
+
     private static void ApplyMooches(this GameData data)
     {
         foreach (var fish in data.Fishes.Values.Where(f => !f.IsSpearFish))

--- a/GatherBuddy.GameData/Data/Fish/DataBase.cs
+++ b/GatherBuddy.GameData/Data/Fish/DataBase.cs
@@ -27,7 +27,7 @@ public static partial class Fish
 
     private static Classes.Fish? Transition(this Classes.Fish? fish, GameData data, params uint[] previousWeathers)
     {
-        if (fish == null)
+        if (fish is null)
             return null;
 
         try
@@ -36,7 +36,10 @@ public static partial class Fish
                     ? weather
                     : throw new Exception($"Could not find weather {w}."))
                 .ToArray();
-            fish.FishRestrictions |= FishRestrictions.Weather;
+            if (fish.PreviousWeather.Length > 0)
+                fish.FishRestrictions |= FishRestrictions.Weather;
+            else if (fish.CurrentWeather.Length is 0)
+                fish.FishRestrictions &= ~FishRestrictions.Weather;
         }
         catch (Exception e)
         {
@@ -57,7 +60,10 @@ public static partial class Fish
                     ? weather
                     : throw new Exception($"Could not find weather {w}."))
                 .ToArray();
-            fish.FishRestrictions |= FishRestrictions.Weather;
+            if (fish.CurrentWeather.Length > 0)
+                fish.FishRestrictions |= FishRestrictions.Weather;
+            else if (fish.PreviousWeather.Length is 0)
+                fish.FishRestrictions &= ~FishRestrictions.Weather;
         }
         catch (Exception e)
         {
@@ -480,7 +486,17 @@ public static partial class Fish
                         fish.Snag(data, snagging ? Snagging.Required : Snagging.None);
 
                     if (custom is { UptimeMinuteOfDayStart: { } start, UptimeMinuteOfDayEnd: { } end })
-                        fish.Time(start, end);
+                    {
+                        if (start % 1440 == end % 1440)
+                        {
+                            fish.FishRestrictions &= ~FishRestrictions.Time;
+                            fish.Interval         =  RepeatingInterval.Always;
+                        }
+                        else
+                        {
+                            fish.Time(start, end);
+                        }
+                    }
 
                     if (custom.Transition is { } transition)
                         fish.Transition(data, transition);

--- a/GatherBuddy.GameData/Enums/OceanSpecies.cs
+++ b/GatherBuddy.GameData/Enums/OceanSpecies.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace GatherBuddy.Enums;
+
+[Flags]
+public enum OceanSpecies : byte
+{
+    None,
+    Octopus,
+    Shark,
+    Jellyfish,
+    Seadragon,
+    Fugu,
+    Crab,
+    Manta,
+    Shellfish,
+    Squid,
+    Shrimp,
+}

--- a/GatherBuddy/Config/Configuration.cs
+++ b/GatherBuddy/Config/Configuration.cs
@@ -88,6 +88,7 @@ public partial class Configuration : IPluginConfiguration
     public int    SecondIntervalsRounding { get; set; } = 1;
     public bool   ShowCollectableHints    { get; set; } = true;
     public bool   ShowMultiHookHints      { get; set; } = true;
+    public bool   ShowOceanTypeHints      { get; set; } = true;
     
     // Fish Stats Tab
     public bool EnableFishStats       { get; set; } = false;

--- a/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
@@ -28,28 +28,37 @@ public partial class FishTimerWindow
 
     public static readonly ISharedImmediateTexture QuadHookIcon =
         Dalamud.Textures.GetFromManifestResource(Assembly.GetExecutingAssembly(), "QuadHookIcon.bmp");
-    
+
     public static readonly ISharedImmediateTexture OctopusIcon =
         Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065913));
+
     public static readonly ISharedImmediateTexture SharkIcon =
         Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065914));
+
     public static readonly ISharedImmediateTexture JellyfishIcon =
         Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065915));
+
     public static readonly ISharedImmediateTexture SeadragonIcon =
         Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065916));
+
     public static readonly ISharedImmediateTexture FuguIcon =
         Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065917));
+
     public static readonly ISharedImmediateTexture CrabIcon =
         Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065918));
+
     public static readonly ISharedImmediateTexture MantaIcon =
         Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065919));
+
     public static readonly ISharedImmediateTexture ShellfishIcon =
         Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065930));
+
     public static readonly ISharedImmediateTexture SquidIcon =
         Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065931));
+
     public static readonly ISharedImmediateTexture ShrimpIcon =
         Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065932));
-    
+
 
     private readonly struct FishCache
     {
@@ -221,19 +230,17 @@ public partial class FishTimerWindow
             size.X -= window._iconSize.X;
             DrawMarkers(ptr, pos, size.Y, size.X);
         }
-        
-        private int TripleHookCount(int x)
-        {
-            return x switch
+
+        private static int TripleHookCount(int x)
+            => x switch
             {
                 1 => 1,
                 2 => 3,
                 3 => 5,
                 4 => 7,
                 5 => 8,
-                _ => 1
+                _ => 1,
             };
-        }
 
         public void Draw(FishTimerWindow window)
         {
@@ -289,7 +296,7 @@ public partial class FishTimerWindow
                     ImGuiHelpers.ScaledVector2(30, 30), true);
                 window._style.Pop();
             }
-            
+
             if (multiHook)
             {
                 ImGui.SameLine(window._windowSize.X - window._iconSize.X);
@@ -309,18 +316,20 @@ public partial class FishTimerWindow
                     {
                         using var tooltip = ImRaii.Tooltip();
                         window._style.Push(ImGuiStyleVar.ItemSpacing, window._originalSpacing);
-                        
+
                         if (_fish.MutliHookUpper == _fish.MultiHookLower)
                         {
-                            ImUtf8.Text($"Double Hook for {_fish.MultiHookLower} fish{(_fish.Points > 0 ? $" worth {_fish.Points * _fish.MultiHookLower} points" : "")}");
-                            ImUtf8.Text($"Triple Hook for {TripleHookCount(_fish.MultiHookLower)} fish{(_fish.Points > 0 ? $" worth {_fish.Points * TripleHookCount(_fish.MultiHookLower)} points" : "")}"); 
+                            ImUtf8.Text(
+                                $"Double Hook for {_fish.MultiHookLower} fish{(_fish.Points > 0 ? $" worth {_fish.Points * _fish.MultiHookLower} points" : "")}");
+                            ImUtf8.Text(
+                                $"Triple Hook for {TripleHookCount(_fish.MultiHookLower)} fish{(_fish.Points > 0 ? $" worth {_fish.Points * TripleHookCount(_fish.MultiHookLower)} points" : "")}");
                         }
                         else
                         {
-                            ImUtf8.Text($"Double Hook for {_fish.MultiHookLower}-{_fish.MutliHookUpper} fish" +
-                                $"{(_fish.Points > 0 ? $" worth between {_fish.Points * _fish.MultiHookLower} and {_fish.Points * _fish.MutliHookUpper} points" : "")}");
-                            ImUtf8.Text($"Triple Hook for {TripleHookCount(_fish.MultiHookLower)}-{TripleHookCount(_fish.MutliHookUpper)} fish" +
-                                $"{(_fish.Points > 0 ? $" worth between {_fish.Points * (TripleHookCount(_fish.MultiHookLower))} and {_fish.Points * TripleHookCount(_fish.MutliHookUpper)} points" : "")}");
+                            ImUtf8.Text($"Double Hook for {_fish.MultiHookLower}-{_fish.MutliHookUpper} fish"
+                              + $"{(_fish.Points > 0 ? $" worth between {_fish.Points * _fish.MultiHookLower} and {_fish.Points * _fish.MutliHookUpper} points" : "")}");
+                            ImUtf8.Text($"Triple Hook for {TripleHookCount(_fish.MultiHookLower)}-{TripleHookCount(_fish.MutliHookUpper)} fish"
+                              + $"{(_fish.Points > 0 ? $" worth between {_fish.Points * TripleHookCount(_fish.MultiHookLower)} and {_fish.Points * TripleHookCount(_fish.MutliHookUpper)} points" : "")}");
                         }
 
                         window._style.Pop();
@@ -331,11 +340,11 @@ public partial class FishTimerWindow
                     ImGui.Dummy(window._iconSize);
                 }
             }
-            
+
             if (oceanType)
             {
                 ImGui.SameLine(window._windowSize.X - window._iconSize.X - (multiHook ? window._iconSize.X : 0));
-                
+
                 var typeIcon = _fish.OceanSpecies switch
                 {
                     OceanSpecies.Octopus   => OctopusIcon,
@@ -350,7 +359,7 @@ public partial class FishTimerWindow
                     OceanSpecies.Shrimp    => ShrimpIcon,
                     _                      => null,
                 };
-                
+
                 if (typeIcon?.TryGetWrap(out var wrap2, out _) ?? false)
                 {
                     ImGui.Image(wrap2.Handle, window._iconSize);
@@ -358,9 +367,9 @@ public partial class FishTimerWindow
                     {
                         using var tooltip = ImRaii.Tooltip();
                         window._style.Push(ImGuiStyleVar.ItemSpacing, window._originalSpacing);
-                        
+
                         ImUtf8.Text($"This fish is a {_fish.OceanSpecies.ToString().ToLower()}");
-                        
+
                         window._style.Pop();
                     }
                 }
@@ -377,7 +386,10 @@ public partial class FishTimerWindow
                     ? Vector4.One
                     : new Vector4(0.75f, 0.75f, 0.75f, 0.5f);
 
-                ImGui.SameLine(window._windowSize.X - window._iconSize.X - (multiHook ? window._iconSize.X : 0) - (oceanType ? window._iconSize.X : 0));
+                ImGui.SameLine(window._windowSize.X
+                  - window._iconSize.X
+                  - (multiHook ? window._iconSize.X : 0)
+                  - (oceanType ? window._iconSize.X : 0));
                 if (CollectableIcon.TryGetWrap(out var wrap3, out _))
                     ImGui.Image(wrap3.Handle, window._iconSize, Vector2.Zero, Vector2.One, tint);
                 else
@@ -388,7 +400,10 @@ public partial class FishTimerWindow
             if (timeString is null)
                 return;
 
-            var offset = ImGui.CalcTextSize(timeString).X + (collectible ? window._iconSize.X : 0) + (multiHook ? window._iconSize.X : 0) + (oceanType ? window._iconSize.X : 0);
+            var offset = ImGui.CalcTextSize(timeString).X
+              + (collectible ? window._iconSize.X : 0)
+              + (multiHook ? window._iconSize.X : 0)
+              + (oceanType ? window._iconSize.X : 0);
             ImGui.SameLine(window._windowSize.X - offset - padding);
             ImUtf8.TextFrameAligned(timeString);
         }

--- a/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
@@ -270,7 +270,7 @@ public partial class FishTimerWindow
             var       clipRectMax = clipRectMin + ImGui.GetContentRegionAvail();
             var       collectible = _fish.Collectible && GatherBuddy.Config.ShowCollectableHints;
             var       multiHook   = _fish.MultiHookLower > 1 && GatherBuddy.Config.ShowMultiHookHints;
-            var       oceanType   = _fish.OceanSpecies != 0 && GatherBuddy.Config.ShowOceanTypeHints;
+            var       oceanType   = _fish.OceanSpecies is not 0 && GatherBuddy.Config.ShowOceanTypeHints;
             if (collectible)
                 clipRectMax.X -= window._iconSize.X;
             if (multiHook)

--- a/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
@@ -224,7 +224,15 @@ public partial class FishTimerWindow
         
         private int TripleHookCount(int x)
         {
-            return (int)Math.Round(Math.Pow(x,3)/6 + 3 * Math.Pow(x, 2)/2 - 7*(float)x/3 + 3);
+            return x switch
+            {
+                1 => 1,
+                2 => 3,
+                3 => 5,
+                4 => 7,
+                5 => 8,
+                _ => 1
+            };
         }
 
         public void Draw(FishTimerWindow window)

--- a/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
@@ -28,6 +28,28 @@ public partial class FishTimerWindow
 
     public static readonly ISharedImmediateTexture QuadHookIcon =
         Dalamud.Textures.GetFromManifestResource(Assembly.GetExecutingAssembly(), "QuadHookIcon.bmp");
+    
+    public static readonly ISharedImmediateTexture OctopusIcon =
+        Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065913));
+    public static readonly ISharedImmediateTexture SharkIcon =
+        Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065914));
+    public static readonly ISharedImmediateTexture JellyfishIcon =
+        Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065915));
+    public static readonly ISharedImmediateTexture SeadragonIcon =
+        Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065916));
+    public static readonly ISharedImmediateTexture FuguIcon =
+        Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065917));
+    public static readonly ISharedImmediateTexture CrabIcon =
+        Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065918));
+    public static readonly ISharedImmediateTexture MantaIcon =
+        Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065919));
+    public static readonly ISharedImmediateTexture ShellfishIcon =
+        Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065930));
+    public static readonly ISharedImmediateTexture SquidIcon =
+        Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065931));
+    public static readonly ISharedImmediateTexture ShrimpIcon =
+        Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065932));
+    
 
     private readonly struct FishCache
     {
@@ -199,6 +221,11 @@ public partial class FishTimerWindow
             size.X -= window._iconSize.X;
             DrawMarkers(ptr, pos, size.Y, size.X);
         }
+        
+        private int TripleHookCount(int x)
+        {
+            return (int)Math.Round(Math.Pow(x,3)/6 + 3 * Math.Pow(x, 2)/2 - 7*(float)x/3 + 3);
+        }
 
         public void Draw(FishTimerWindow window)
         {
@@ -228,9 +255,12 @@ public partial class FishTimerWindow
             var       clipRectMax = clipRectMin + ImGui.GetContentRegionAvail();
             var       collectible = _fish.Collectible && GatherBuddy.Config.ShowCollectableHints;
             var       multiHook   = _fish.MultiHookLower > 1 && GatherBuddy.Config.ShowMultiHookHints;
+            var       oceanType   = _fish.OceanSpecies != 0 && GatherBuddy.Config.ShowOceanTypeHints;
             if (collectible)
                 clipRectMax.X -= window._iconSize.X;
             if (multiHook)
+                clipRectMax.X -= window._iconSize.X;
+            if (oceanType)
                 clipRectMax.X -= window._iconSize.X;
             if (textWidth > 0)
                 clipRectMax.X -= textWidth + window._originalSpacing.X + padding;
@@ -251,7 +281,7 @@ public partial class FishTimerWindow
                     ImGuiHelpers.ScaledVector2(30, 30), true);
                 window._style.Pop();
             }
-
+            
             if (multiHook)
             {
                 ImGui.SameLine(window._windowSize.X - window._iconSize.X);
@@ -275,20 +305,54 @@ public partial class FishTimerWindow
                         if (_fish.MutliHookUpper == _fish.MultiHookLower)
                         {
                             ImUtf8.Text($"Double Hook for {_fish.MultiHookLower} fish{(_fish.Points > 0 ? $" worth {_fish.Points * _fish.MultiHookLower} points" : "")}");
-                            ImUtf8.Text($"Triple Hook for {2 * _fish.MultiHookLower - 1} fish{(_fish.Points > 0 ? $" worth {_fish.Points * (2 * _fish.MultiHookLower - 1)} points" : "")}"); 
-                            //TODO: This formula breaks for Deepmoon Seadragon which triple hooks to 8 instead of 9 as would be expected.
-                            //Feels like there should be a more proper solution, but as of right now since there are no 5/9 fish to counter example:
-                            //TH=(-3*x^3+9x^2-14x^2+18)/6 does work.
+                            ImUtf8.Text($"Triple Hook for {TripleHookCount(_fish.MultiHookLower)} fish{(_fish.Points > 0 ? $" worth {_fish.Points * TripleHookCount(_fish.MultiHookLower)} points" : "")}"); 
                         }
                         else
                         {
                             ImUtf8.Text($"Double Hook for {_fish.MultiHookLower}-{_fish.MutliHookUpper} fish" +
                                 $"{(_fish.Points > 0 ? $" worth between {_fish.Points * _fish.MultiHookLower} and {_fish.Points * _fish.MutliHookUpper} points" : "")}");
-                            ImUtf8.Text($"Triple Hook for {2 * _fish.MultiHookLower - 1}-{2 * _fish.MutliHookUpper - 1} fish" +
-                                $"{(_fish.Points > 0 ? $" worth between {_fish.Points * (2 * _fish.MultiHookLower - 1)} and {_fish.Points * (2 * _fish.MutliHookUpper - 1)} points" : "")}");
-                            //TODO: See above
+                            ImUtf8.Text($"Triple Hook for {TripleHookCount(_fish.MultiHookLower)}-{TripleHookCount(_fish.MutliHookUpper)} fish" +
+                                $"{(_fish.Points > 0 ? $" worth between {_fish.Points * (TripleHookCount(_fish.MultiHookLower))} and {_fish.Points * TripleHookCount(_fish.MutliHookUpper)} points" : "")}");
                         }
 
+                        window._style.Pop();
+                    }
+                }
+                else
+                {
+                    ImGui.Dummy(window._iconSize);
+                }
+            }
+            
+            if (oceanType)
+            {
+                ImGui.SameLine(window._windowSize.X - window._iconSize.X - (multiHook ? window._iconSize.X : 0));
+                
+                var typeIcon = _fish.OceanSpecies switch
+                {
+                    OceanSpecies.Octopus   => OctopusIcon,
+                    OceanSpecies.Shark     => SharkIcon,
+                    OceanSpecies.Jellyfish => JellyfishIcon,
+                    OceanSpecies.Seadragon => SeadragonIcon,
+                    OceanSpecies.Fugu      => FuguIcon,
+                    OceanSpecies.Crab      => CrabIcon,
+                    OceanSpecies.Manta     => MantaIcon,
+                    OceanSpecies.Shellfish => ShellfishIcon,
+                    OceanSpecies.Squid     => SquidIcon,
+                    OceanSpecies.Shrimp    => ShrimpIcon,
+                    _                      => null,
+                };
+                
+                if (typeIcon?.TryGetWrap(out var wrap2, out _) ?? false)
+                {
+                    ImGui.Image(wrap2.Handle, window._iconSize);
+                    if (ImGui.IsItemHovered())
+                    {
+                        using var tooltip = ImRaii.Tooltip();
+                        window._style.Push(ImGuiStyleVar.ItemSpacing, window._originalSpacing);
+                        
+                        ImUtf8.Text($"This fish is a {_fish.OceanSpecies.ToString().ToLower()}");
+                        
                         window._style.Pop();
                     }
                 }
@@ -305,7 +369,7 @@ public partial class FishTimerWindow
                     ? Vector4.One
                     : new Vector4(0.75f, 0.75f, 0.75f, 0.5f);
 
-                ImGui.SameLine(window._windowSize.X - window._iconSize.X - (multiHook ? window._iconSize.X : 0));
+                ImGui.SameLine(window._windowSize.X - window._iconSize.X - (multiHook ? window._iconSize.X : 0) - (oceanType ? window._iconSize.X : 0));
                 if (CollectableIcon.TryGetWrap(out var wrap3, out _))
                     ImGui.Image(wrap3.Handle, window._iconSize, Vector2.Zero, Vector2.One, tint);
                 else

--- a/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
@@ -388,7 +388,7 @@ public partial class FishTimerWindow
             if (timeString is null)
                 return;
 
-            var offset = ImGui.CalcTextSize(timeString).X + (collectible ? window._iconSize.X : 0) + (multiHook ? window._iconSize.X : 0);
+            var offset = ImGui.CalcTextSize(timeString).X + (collectible ? window._iconSize.X : 0) + (multiHook ? window._iconSize.X : 0) + (oceanType ? window._iconSize.X : 0);
             ImGui.SameLine(window._windowSize.X - offset - padding);
             ImUtf8.TextFrameAligned(timeString);
         }

--- a/GatherBuddy/GatherBuddy.csproj
+++ b/GatherBuddy/GatherBuddy.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>GatherBuddy</RootNamespace>
     <AssemblyName>GatherBuddy</AssemblyName>
-    <Version>3.8.5.2</Version>
+    <Version>3.8.6.0</Version>
     <Company>SoftOtter</Company>
     <Product>GatherBuddy</Product>
     <Copyright>Copyright © 2025</Copyright>

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -348,9 +348,12 @@ public partial class Interface
 
         public static void DrawDoubleHookHintPopupBox()
             => DrawCheckbox("Show Multi Hook Hints",
-                "Show if a fish can be double or triple hooked in Cosmic Exploration.", // TODO: add ocean fishing when implemented.
+                "Show if a fish can be double or triple hooked in Cosmic Exploration and Ocean Fishing",
                 GatherBuddy.Config.ShowMultiHookHints, b => GatherBuddy.Config.ShowMultiHookHints = b);
-        
+        public static void DrawOceanTypeHintPopupBox()
+            => DrawCheckbox("Show Ocean Type Hints",
+                "Show what type of fish in Ocean Fishing",
+                GatherBuddy.Config.ShowOceanTypeHints, b => GatherBuddy.Config.ShowOceanTypeHints = b);
         
         // Fish Stats Window
         public static void DrawEnableFishStats()

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -649,6 +649,7 @@ public partial class Interface
                 ConfigFunctions.DrawHideFishPopupBox();
                 ConfigFunctions.DrawCollectableHintPopupBox();
                 ConfigFunctions.DrawDoubleHookHintPopupBox();
+                ConfigFunctions.DrawOceanTypeHintPopupBox();
                 ImGui.TreePop();
             }
 

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -145,6 +145,46 @@ public partial class Interface
             ImGui.SameLine();
             if (FishTimerWindow.QuadHookIcon.TryGetWrap(out var wrapQuadHook, out _))
                 ImGui.Image(wrapQuadHook.Handle, wrapQuadHook.Size);
+            
+            ImGui.SameLine();
+            if (FishTimerWindow.OctopusIcon.TryGetWrap(out var wrapOctopus, out _))
+                ImGui.Image(wrapOctopus.Handle, wrapOctopus.Size);
+
+            ImGui.SameLine();
+            if (FishTimerWindow.SharkIcon.TryGetWrap(out var wrapShark, out _))
+                ImGui.Image(wrapShark.Handle, wrapShark.Size);
+
+            ImGui.SameLine();
+            if (FishTimerWindow.JellyfishIcon.TryGetWrap(out var wrapJellyfish, out _))
+                ImGui.Image(wrapJellyfish.Handle, wrapJellyfish.Size);
+
+            ImGui.SameLine();
+            if (FishTimerWindow.SeadragonIcon.TryGetWrap(out var wrapSeadragon, out _))
+                ImGui.Image(wrapSeadragon.Handle, wrapSeadragon.Size);
+
+            ImGui.SameLine();
+            if (FishTimerWindow.FuguIcon.TryGetWrap(out var wrapFugu, out _))
+                ImGui.Image(wrapFugu.Handle, wrapFugu.Size);
+
+            ImGui.SameLine();
+            if (FishTimerWindow.CrabIcon.TryGetWrap(out var wrapCrab, out _))
+                ImGui.Image(wrapCrab.Handle, wrapCrab.Size);
+
+            ImGui.SameLine();
+            if (FishTimerWindow.MantaIcon.TryGetWrap(out var wrapManta, out _))
+                ImGui.Image(wrapManta.Handle, wrapManta.Size);
+
+            ImGui.SameLine();
+            if (FishTimerWindow.ShellfishIcon.TryGetWrap(out var wrapShellfish, out _))
+                ImGui.Image(wrapShellfish.Handle, wrapShellfish.Size);
+
+            ImGui.SameLine();
+            if (FishTimerWindow.SquidIcon.TryGetWrap(out var wrapSquid, out _))
+                ImGui.Image(wrapSquid.Handle, wrapSquid.Size);
+
+            ImGui.SameLine();
+            if (FishTimerWindow.ShrimpIcon.TryGetWrap(out var wrapShrimp, out _))
+                ImGui.Image(wrapShrimp.Handle, wrapShrimp.Size);
         }
     }
 

--- a/GatherBuddy/Gui/Interface.FishTab.ExtendedFish.cs
+++ b/GatherBuddy/Gui/Interface.FishTab.ExtendedFish.cs
@@ -80,6 +80,9 @@ public partial class Interface
 
         public byte MultiHookLower
             => Data.MultiHookLower;
+        
+        public OceanSpecies OceanSpecies
+            => Data.OceanSpecies;
 
         public byte MutliHookUpper
             => Data.MultiHookUpper;


### PR DESCRIPTION
Update all oceanfish to match oceanfishing.boats. Source information from https://github.com/netsua92/OceanFishing/blob/main/fishdata/indigo-EN.csv and the ruby-EN.csv.

Also added the Species type and Icon for the type to the fish + fishing window + config option. 
For the icons, couldn't find the EXACT icons used in the ocean fishing journey. It looks like they may be loaded from a texture instead of an icon? But I was able to find the mission completion icons, so I am using those. 

Also fixed the Triple Hook function for the 5->8 fish.

Tried to verify everything works properly, but there's only so many tests I can do during the 15 minute windows every 2 hours. 
Most of it is automated so if some of it works, presumably all of it does. 