### PR TITLE
Add info for the new ocean fish

### DIFF
--- a/GatherBuddy.GameData/Data/Fish/Data6.4.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data6.4.cs
@@ -148,7 +148,8 @@ public static partial class Fish
             .Points    (102)
             .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
-            .Ocean     (OceanTime.Night);
+            .Ocean     (OceanTime.Night)
+            .OceanType(OceanSpecies.Prehistoric);
         data.Apply(40537, Patch.TheDarkThrone) // Impostopus
             .Bait      (data, 29715)
             .Points    (144)
@@ -160,19 +161,22 @@ public static partial class Fish
             .Points    (72)
             .MultiHook (2)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
-            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
+            .Ocean     (OceanTime.Day, OceanTime.Sunset, OceanTime.Night)
+            .OceanType(OceanSpecies.Mantis);
         data.Apply(40539, Patch.TheDarkThrone) // Nymeia's Wheel
             .Bait      (data, 29715)
             .Points    (289)
             .MultiHook (2)
             .Bite      (data, HookSet.Powerful, BiteType.Strong)
-            .Ocean     (OceanTime.Sunset);
+            .Ocean     (OceanTime.Sunset)
+            .OceanType(OceanSpecies.Prehistoric);
         data.Apply(40540, Patch.TheDarkThrone) // Taniwha
             .Bait      (data, 36593)
             .Points    (500)
             .Bite      (data, HookSet.Powerful, BiteType.Legendary)
             .Ocean     (OceanTime.Day)
-            .Predators (data, 15, (40534, 3));
+            .Predators (data, 15, (40534, 3))
+            .OceanType(OceanSpecies.Prehistoric);
         data.Apply(40541, Patch.TheDarkThrone) // Ruby Herring
             .Bait      (data, 29715)
             .Points    (14)

--- a/GatherBuddy.GameData/Data/Fish/Data7.5.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data7.5.cs
@@ -54,122 +54,203 @@ public static partial class Fish
 
         // Ocean Fish
         data.Apply(51209, Patch.TrailToTheHeavens) // First Mate's Finger
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29714)
+            .Points(10)
+            .Bite(data, HookSet.Precise, BiteType.Weak)
+            .OceanType(OceanSpecies.Mantis);
         data.Apply(51210, Patch.TrailToTheHeavens) // Specterfish
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29715)
+            .Points(15)
+            .Bite(data, HookSet.Powerful, BiteType.Strong)
+            .Weather(data, 1, 2, 3, 4);
         data.Apply(51211, Patch.TrailToTheHeavens) // Rhotano Permit
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29716)
+            .Points(11)
+            .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(51212, Patch.TrailToTheHeavens) // Rhotano Dahlia
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29715)
+            .Points(35)
+            .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(51213, Patch.TrailToTheHeavens) // Lodesmate's Pen
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29715)
+            .Points(35)
+            .Bite(data, HookSet.Powerful, BiteType.Strong)
+            .Weather(data, 1, 2, 3, 4, 7);
         data.Apply(51214, Patch.TrailToTheHeavens) // Rhotano Roosterfish
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29716)
+            .Points(40)
+            .Bite(data, HookSet.Powerful, BiteType.Strong)
+            .Weather(data, 1, 2, 7, 8);
         data.Apply(51215, Patch.TrailToTheHeavens) // Rhotanosaurus
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29716)
+            .Points(59)
+            .Bite(data, HookSet.Powerful, BiteType.Legendary)
+            .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51216, Patch.TrailToTheHeavens) // Royal Handmaiden
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29714)
+            .Points(52)
+            .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(51217, Patch.TrailToTheHeavens) // Spectral Starfish
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29714)
+            .Points(100)
+            .Bite(data, HookSet.Precise, BiteType.Legendary)
+            .Weather(data, 2, 3, 4, 7, 8);
         data.Apply(51218, Patch.TrailToTheHeavens) // Frolicsome Fish
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29714)
+            .Points(236)
+            .Bite(data, HookSet.Precise, BiteType.Legendary)
+            .Predators(data, 60, (51212, 3));
         data.Apply(51219, Patch.TrailToTheHeavens) // Captain's Finger
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29714)
+            .Points(86)
+            .Bite(data, HookSet.Precise, BiteType.Weak)
+            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night)
+            .OceanType(OceanSpecies.Mantis);
         data.Apply(51220, Patch.TrailToTheHeavens) // Bright Red Coral
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29715)
+            .Points(84)
+            .Bite(data, HookSet.Precise, BiteType.Weak)
+            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(51221, Patch.TrailToTheHeavens) // Royal Favorite
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29714)
+            .Points(69)
+            .Bite(data, HookSet.Precise, BiteType.Weak)
+            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(51222, Patch.TrailToTheHeavens) // Pirate's Purse
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29714)
+            .Points(199)
+            .Bite(data, HookSet.Precise, BiteType.Weak)
+            .Ocean(OceanTime.Night);
         data.Apply(51223, Patch.TrailToTheHeavens) // Captain's Pen
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29715)
+            .Points(58)
+            .Bite(data, HookSet.Powerful, BiteType.Strong)
+            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(51224, Patch.TrailToTheHeavens) // Tylosaurus
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29716)
+            .Points(68)
+            .Bite(data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night)
+            .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51225, Patch.TrailToTheHeavens) // Cieldalaes Roosterfish
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Mooch(data, 51223)
+            .Points(100)
+            .Bite(data, HookSet.Powerful, BiteType.Strong)
+            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night)
+            .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51226, Patch.TrailToTheHeavens) // Renegade Rhotanosaurus
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29716)
+            .Points(160)
+            .Bite(data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean(OceanTime.Sunset);
         data.Apply(51227, Patch.TrailToTheHeavens) // Red Boarfish
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29715)
+            .Points(200)
+            .Bite(data, HookSet.Powerful, BiteType.Strong)
+            .Ocean(OceanTime.Day);
         data.Apply(51228, Patch.TrailToTheHeavens) // Akupara
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Mooch(data, 29714, 51223, 51225)
+            .Points(500)
+            .Bite(data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean(OceanTime.Sunset)
+            .Predators(data, 20, (51225, 2))
+            .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51229, Patch.TrailToTheHeavens) // Red Mantis
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29714)
+            .Points(8)
+            .Bite(data, HookSet.Precise, BiteType.Weak)
+            .OceanType(OceanSpecies.Mantis);
         data.Apply(51230, Patch.TrailToTheHeavens) // Datli Gwl
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29715)
+            .Points(9)
+            .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(51231, Patch.TrailToTheHeavens) // Agama's Strand
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29714)
+            .Points(13)
+            .Bite(data, HookSet.Precise, BiteType.Weak)
+            .Weather(data, 1, 2, 3, 4);
         data.Apply(51232, Patch.TrailToTheHeavens) // Palaka's Blade
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29714)
+            .Points(36)
+            .Bite(data, HookSet.Precise, BiteType.Weak)
+            .Weather(data, 1, 2, 3, 4, 7);
         data.Apply(51233, Patch.TrailToTheHeavens) // Parjanya Wrasse
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29715)
+            .Points(31)
+            .Bite(data, HookSet.Powerful, BiteType.Strong)
+            .Weather(data, 1, 2, 7, 8);
         data.Apply(51234, Patch.TrailToTheHeavens) // Simolestes
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29716)
+            .Points(27)
+            .Bite(data, HookSet.Powerful, BiteType.Strong)
+            .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51235, Patch.TrailToTheHeavens) // Thavnasaurus
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29716)
+            .Points(48)
+            .Bite(data, HookSet.Powerful, BiteType.Legendary)
+            .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51237, Patch.TrailToTheHeavens) // Spectral Grouper
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29715)
+            .Points(100)
+            .Bite(data, HookSet.Powerful, BiteType.Legendary)
+            .Weather(data, 2, 3, 4, 7, 8);
         data.Apply(51238, Patch.TrailToTheHeavens) // Silkfin
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29715)
+            .Points(210)
+            .Bite(data, HookSet.Powerful, BiteType.Legendary)
+            .Predators(data, 60, (51229, 3));
         data.Apply(51239, Patch.TrailToTheHeavens) // Great Red Mantis
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29714)
+            .Points(75)
+            .Bite(data, HookSet.Precise, BiteType.Weak)
+            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(51240, Patch.TrailToTheHeavens) // Guzel Gwl
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29715)
+            .Points(70)
+            .Bite(data, HookSet.Powerful, BiteType.Strong)
+            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(51241, Patch.TrailToTheHeavens) // Darpana
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29715)
+            .Points(92)
+            .Bite(data, HookSet.Precise, BiteType.Weak)
+            .Ocean(OceanTime.Day);
         data.Apply(51242, Patch.TrailToTheHeavens) // Silverdart
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29715)
+            .Points(164)
+            .Bite(data, HookSet.Powerful, BiteType.Strong)
+            .Ocean(OceanTime.Sunset);
         data.Apply(51243, Patch.TrailToTheHeavens) // Satrapsaurus
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29716)
+            .Points(70)
+            .Bite(data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(51244, Patch.TrailToTheHeavens) // Tiger Mantis
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29714)
+            .Points(150)
+            .Bite(data, HookSet.Precise, BiteType.Weak)
+            .Ocean(OceanTime.Sunset, OceanTime.Night);
         data.Apply(51245, Patch.TrailToTheHeavens) // Mehi-mahi
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29716)
+            .Points(70)
+            .Bite(data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
         data.Apply(51246, Patch.TrailToTheHeavens) // Pliosaurus
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 29716)
+            .Points(204)
+            .Bite(data, HookSet.Powerful, BiteType.Legendary)
+            .Ocean(OceanTime.Day)
+            .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51247, Patch.TrailToTheHeavens) // Manasvin
-            .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Bait(data, 2591)
+            .Points(500)
+            .Bite(data, HookSet.Unknown, BiteType.Legendary)
+            .Ocean(OceanTime.Night)
+            .Predators(data, 15, (51243, 2));
         data.Apply(51687, Patch.TrailToTheHeavens) // Junior Jinbei
             .Bait(data)
-            .Bite(data, HookSet.Unknown, BiteType.Unknown);
+            .Points(300)
+            .Bite(data, HookSet.Precise, BiteType.Weak)
+            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
     }
     // @formatter:on
 }

--- a/GatherBuddy.GameData/Data/Fish/Data7.5.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data7.5.cs
@@ -104,18 +104,18 @@ public static partial class Fish
             .Bait(data, 29714)
             .Points(86)
             .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night)
+            .Ocean(OceanTime.Always)
             .OceanType(OceanSpecies.Mantis);
         data.Apply(51220, Patch.TrailToTheHeavens) // Bright Red Coral
             .Bait(data, 29715)
             .Points(84)
             .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
+            .Ocean(OceanTime.Always);
         data.Apply(51221, Patch.TrailToTheHeavens) // Royal Favorite
             .Bait(data, 29714)
             .Points(69)
             .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
+            .Ocean(OceanTime.Always);
         data.Apply(51222, Patch.TrailToTheHeavens) // Pirate's Purse
             .Bait(data, 29714)
             .Points(199)
@@ -125,18 +125,18 @@ public static partial class Fish
             .Bait(data, 29715)
             .Points(58)
             .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
+            .Ocean(OceanTime.Always);
         data.Apply(51224, Patch.TrailToTheHeavens) // Tylosaurus
             .Bait(data, 29716)
             .Points(68)
             .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night)
+            .Ocean(OceanTime.Always)
             .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51225, Patch.TrailToTheHeavens) // Cieldalaes Roosterfish
             .Mooch(data, 51223)
             .Points(100)
             .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night)
+            .Ocean(OceanTime.Always)
             .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51226, Patch.TrailToTheHeavens) // Renegade Rhotanosaurus
             .Bait(data, 29716)
@@ -203,12 +203,12 @@ public static partial class Fish
             .Bait(data, 29714)
             .Points(75)
             .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
+            .Ocean(OceanTime.Always);
         data.Apply(51240, Patch.TrailToTheHeavens) // Guzel Gwl
             .Bait(data, 29715)
             .Points(70)
             .Bite(data, HookSet.Powerful, BiteType.Strong)
-            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
+            .Ocean(OceanTime.Always);
         data.Apply(51241, Patch.TrailToTheHeavens) // Darpana
             .Bait(data, 29715)
             .Points(92)
@@ -223,7 +223,7 @@ public static partial class Fish
             .Bait(data, 29716)
             .Points(70)
             .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
+            .Ocean(OceanTime.Always);
         data.Apply(51244, Patch.TrailToTheHeavens) // Tiger Mantis
             .Bait(data, 29714)
             .Points(150)
@@ -233,7 +233,7 @@ public static partial class Fish
             .Bait(data, 29716)
             .Points(70)
             .Bite(data, HookSet.Powerful, BiteType.Legendary)
-            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
+            .Ocean(OceanTime.Always);
         data.Apply(51246, Patch.TrailToTheHeavens) // Pliosaurus
             .Bait(data, 29716)
             .Points(204)
@@ -250,7 +250,7 @@ public static partial class Fish
             .Bait(data)
             .Points(300)
             .Bite(data, HookSet.Precise, BiteType.Weak)
-            .Ocean(OceanTime.Day, OceanTime.Sunset, OceanTime.Night);
+            .Ocean(OceanTime.Always);
     }
     // @formatter:on
 }

--- a/GatherBuddy.GameData/Data/Fish/Data7.5.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data7.5.cs
@@ -27,7 +27,7 @@ public static partial class Fish
             .Mooch(data, 43740)
             .Weather(data, 7)
             .Transition(data, 1)
-            .Time(960, 1440)
+            .Time(960, 1260)
             .Bite(data, HookSet.Powerful, BiteType.Legendary);
         data.Apply(52003, Patch.TrailToTheHeavens) // Autarch's Supper
             .Bait(data, 43858)
@@ -56,39 +56,47 @@ public static partial class Fish
         data.Apply(51209, Patch.TrailToTheHeavens) // First Mate's Finger
             .Bait(data, 29714)
             .Points(10)
+            .MultiHook (3)
             .Bite(data, HookSet.Precise, BiteType.Weak)
             .OceanType(OceanSpecies.Mantis);
         data.Apply(51210, Patch.TrailToTheHeavens) // Specterfish
             .Bait(data, 29715)
             .Points(15)
+            .MultiHook (2)
             .Bite(data, HookSet.Powerful, BiteType.Strong)
             .Weather(data, 1, 2, 3, 4);
         data.Apply(51211, Patch.TrailToTheHeavens) // Rhotano Permit
             .Bait(data, 29716)
             .Points(11)
+            .MultiHook (2)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(51212, Patch.TrailToTheHeavens) // Rhotano Dahlia
             .Bait(data, 29715)
             .Points(35)
+            .MultiHook (2)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(51213, Patch.TrailToTheHeavens) // Lodesmate's Pen
             .Bait(data, 29715)
             .Points(35)
+            .MultiHook (2)
             .Bite(data, HookSet.Powerful, BiteType.Strong)
             .Weather(data, 1, 2, 3, 4, 7);
         data.Apply(51214, Patch.TrailToTheHeavens) // Rhotano Roosterfish
             .Bait(data, 29716)
             .Points(40)
+            .MultiHook (2)
             .Bite(data, HookSet.Powerful, BiteType.Strong)
             .Weather(data, 1, 2, 7, 8);
         data.Apply(51215, Patch.TrailToTheHeavens) // Rhotanosaurus
             .Bait(data, 29716)
             .Points(59)
+            .MultiHook (3)
             .Bite(data, HookSet.Powerful, BiteType.Legendary)
             .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51216, Patch.TrailToTheHeavens) // Royal Handmaiden
             .Bait(data, 29714)
             .Points(52)
+            .MultiHook (2)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(51217, Patch.TrailToTheHeavens) // Spectral Starfish
             .Bait(data, 29714)
@@ -103,49 +111,58 @@ public static partial class Fish
         data.Apply(51219, Patch.TrailToTheHeavens) // Captain's Finger
             .Bait(data, 29714)
             .Points(86)
+            .MultiHook (4)
             .Bite(data, HookSet.Precise, BiteType.Weak)
             .Ocean(OceanTime.Always)
             .OceanType(OceanSpecies.Mantis);
         data.Apply(51220, Patch.TrailToTheHeavens) // Bright Red Coral
             .Bait(data, 29715)
             .Points(84)
+            .MultiHook (2)
             .Bite(data, HookSet.Precise, BiteType.Weak)
             .Ocean(OceanTime.Always);
         data.Apply(51221, Patch.TrailToTheHeavens) // Royal Favorite
             .Bait(data, 29714)
             .Points(69)
+            .MultiHook (2)
             .Bite(data, HookSet.Precise, BiteType.Weak)
             .Ocean(OceanTime.Always);
         data.Apply(51222, Patch.TrailToTheHeavens) // Pirate's Purse
             .Bait(data, 29714)
             .Points(199)
+            .MultiHook (2)
             .Bite(data, HookSet.Precise, BiteType.Weak)
             .Ocean(OceanTime.Night);
         data.Apply(51223, Patch.TrailToTheHeavens) // Captain's Pen
             .Bait(data, 29715)
             .Points(58)
+            .MultiHook (2)
             .Bite(data, HookSet.Powerful, BiteType.Strong)
             .Ocean(OceanTime.Always);
         data.Apply(51224, Patch.TrailToTheHeavens) // Tylosaurus
             .Bait(data, 29716)
             .Points(68)
+            .MultiHook (3)
             .Bite(data, HookSet.Powerful, BiteType.Legendary)
             .Ocean(OceanTime.Always)
             .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51225, Patch.TrailToTheHeavens) // Cieldalaes Roosterfish
             .Mooch(data, 51223)
             .Points(100)
+            .MultiHook (2)
             .Bite(data, HookSet.Powerful, BiteType.Strong)
             .Ocean(OceanTime.Always)
             .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51226, Patch.TrailToTheHeavens) // Renegade Rhotanosaurus
             .Bait(data, 29716)
             .Points(160)
+            .MultiHook (4)
             .Bite(data, HookSet.Powerful, BiteType.Legendary)
             .Ocean(OceanTime.Sunset);
         data.Apply(51227, Patch.TrailToTheHeavens) // Red Boarfish
             .Bait(data, 29715)
             .Points(200)
+            .MultiHook (2)
             .Bite(data, HookSet.Powerful, BiteType.Strong)
             .Ocean(OceanTime.Day);
         data.Apply(51228, Patch.TrailToTheHeavens) // Akupara
@@ -158,35 +175,42 @@ public static partial class Fish
         data.Apply(51229, Patch.TrailToTheHeavens) // Red Mantis
             .Bait(data, 29714)
             .Points(8)
+            .MultiHook (3)
             .Bite(data, HookSet.Precise, BiteType.Weak)
             .OceanType(OceanSpecies.Mantis);
         data.Apply(51230, Patch.TrailToTheHeavens) // Datli Gwl
             .Bait(data, 29715)
             .Points(9)
+            .MultiHook (2)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(51231, Patch.TrailToTheHeavens) // Agama's Strand
             .Bait(data, 29714)
             .Points(13)
+            .MultiHook (2)
             .Bite(data, HookSet.Precise, BiteType.Weak)
             .Weather(data, 1, 2, 3, 4);
         data.Apply(51232, Patch.TrailToTheHeavens) // Palaka's Blade
             .Bait(data, 29714)
             .Points(36)
+            .MultiHook (2)
             .Bite(data, HookSet.Precise, BiteType.Weak)
             .Weather(data, 1, 2, 3, 4, 7);
         data.Apply(51233, Patch.TrailToTheHeavens) // Parjanya Wrasse
             .Bait(data, 29715)
             .Points(31)
+            .MultiHook (2)
             .Bite(data, HookSet.Powerful, BiteType.Strong)
             .Weather(data, 1, 2, 7, 8);
         data.Apply(51234, Patch.TrailToTheHeavens) // Simolestes
             .Bait(data, 29716)
             .Points(27)
+            .MultiHook (3)
             .Bite(data, HookSet.Powerful, BiteType.Strong)
             .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51235, Patch.TrailToTheHeavens) // Thavnasaurus
             .Bait(data, 29716)
             .Points(48)
+            .MultiHook (3)
             .Bite(data, HookSet.Powerful, BiteType.Legendary)
             .OceanType(OceanSpecies.Prehistoric);
         data.Apply(51237, Patch.TrailToTheHeavens) // Spectral Grouper
@@ -202,41 +226,49 @@ public static partial class Fish
         data.Apply(51239, Patch.TrailToTheHeavens) // Great Red Mantis
             .Bait(data, 29714)
             .Points(75)
+            .MultiHook (3)
             .Bite(data, HookSet.Precise, BiteType.Weak)
             .Ocean(OceanTime.Always);
         data.Apply(51240, Patch.TrailToTheHeavens) // Guzel Gwl
             .Bait(data, 29715)
             .Points(70)
+            .MultiHook (2)
             .Bite(data, HookSet.Powerful, BiteType.Strong)
             .Ocean(OceanTime.Always);
         data.Apply(51241, Patch.TrailToTheHeavens) // Darpana
             .Bait(data, 29715)
             .Points(92)
+            .MultiHook (2)
             .Bite(data, HookSet.Precise, BiteType.Weak)
             .Ocean(OceanTime.Day);
         data.Apply(51242, Patch.TrailToTheHeavens) // Silverdart
             .Bait(data, 29715)
             .Points(164)
+            .MultiHook (2)
             .Bite(data, HookSet.Powerful, BiteType.Strong)
             .Ocean(OceanTime.Sunset);
         data.Apply(51243, Patch.TrailToTheHeavens) // Satrapsaurus
             .Bait(data, 29716)
             .Points(70)
+            .MultiHook (3)
             .Bite(data, HookSet.Powerful, BiteType.Legendary)
             .Ocean(OceanTime.Always);
         data.Apply(51244, Patch.TrailToTheHeavens) // Tiger Mantis
             .Bait(data, 29714)
             .Points(150)
+            .MultiHook (4)
             .Bite(data, HookSet.Precise, BiteType.Weak)
             .Ocean(OceanTime.Sunset, OceanTime.Night);
         data.Apply(51245, Patch.TrailToTheHeavens) // Mehi-mahi
             .Bait(data, 29716)
             .Points(70)
+            .MultiHook (2)
             .Bite(data, HookSet.Powerful, BiteType.Legendary)
             .Ocean(OceanTime.Always);
         data.Apply(51246, Patch.TrailToTheHeavens) // Pliosaurus
             .Bait(data, 29716)
             .Points(204)
+            .MultiHook (4)
             .Bite(data, HookSet.Powerful, BiteType.Legendary)
             .Ocean(OceanTime.Day)
             .OceanType(OceanSpecies.Prehistoric);

--- a/GatherBuddy.GameData/Enums/OceanSpecies.cs
+++ b/GatherBuddy.GameData/Enums/OceanSpecies.cs
@@ -16,4 +16,6 @@ public enum OceanSpecies : byte
     Shellfish,
     Squid,
     Shrimp,
+    Prehistoric,
+    Mantis,
 }

--- a/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
+++ b/GatherBuddy/FishTimer/FishTimerWindow.FishCache.cs
@@ -58,6 +58,12 @@ public partial class FishTimerWindow
 
     public static readonly ISharedImmediateTexture ShrimpIcon =
         Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065932));
+    
+    public static readonly ISharedImmediateTexture PrehistoricIcon =
+        Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065933));
+    
+    public static readonly ISharedImmediateTexture MantisIcon =
+        Icons.DefaultStorage.TextureProvider.GetFromGameIcon(new GameIconLookup(065934));
 
 
     private readonly struct FishCache
@@ -347,17 +353,19 @@ public partial class FishTimerWindow
 
                 var typeIcon = _fish.OceanSpecies switch
                 {
-                    OceanSpecies.Octopus   => OctopusIcon,
-                    OceanSpecies.Shark     => SharkIcon,
-                    OceanSpecies.Jellyfish => JellyfishIcon,
-                    OceanSpecies.Seadragon => SeadragonIcon,
-                    OceanSpecies.Fugu      => FuguIcon,
-                    OceanSpecies.Crab      => CrabIcon,
-                    OceanSpecies.Manta     => MantaIcon,
-                    OceanSpecies.Shellfish => ShellfishIcon,
-                    OceanSpecies.Squid     => SquidIcon,
-                    OceanSpecies.Shrimp    => ShrimpIcon,
-                    _                      => null,
+                    OceanSpecies.Octopus     => OctopusIcon,
+                    OceanSpecies.Shark       => SharkIcon,
+                    OceanSpecies.Jellyfish   => JellyfishIcon,
+                    OceanSpecies.Seadragon   => SeadragonIcon,
+                    OceanSpecies.Fugu        => FuguIcon,
+                    OceanSpecies.Crab        => CrabIcon,
+                    OceanSpecies.Manta       => MantaIcon,
+                    OceanSpecies.Shellfish   => ShellfishIcon,
+                    OceanSpecies.Squid       => SquidIcon,
+                    OceanSpecies.Shrimp      => ShrimpIcon,
+                    OceanSpecies.Prehistoric => PrehistoricIcon,
+                    OceanSpecies.Mantis      => MantisIcon,
+                    _                        => null,
                 };
 
                 if (typeIcon?.TryGetWrap(out var wrap2, out _) ?? false)


### PR DESCRIPTION
Leaving as a draft until I am able to actually do an ocean fishing boat tomorrow and confirm my game doesn't like crash upon entering the zone or something. But, added the info that currently is confirmed for the new ocean fish. For preferred bait in the case where multiple baits work, I went with what oceanfishing.boats. If any of the current bait are proven to not actually be the best one I'll change it.

References:
https://docs.google.com/spreadsheets/d/1R0Nt8Ye7EAQtU8CXF1XRRj67iaFpUk1BXeDgt6abxsQ/edit?gid=1177495245#gid=1177495245

Currently there is a problem with time of day on the Thavnair route, presumably related to this block in GameData.cs needing to be added to or modified. I unfortunately am not sure in what way though.

```csharp
ret[i - 1] = new OceanRoute
            {
                Id         = (byte)i,
                Name       = row.Name.ToDalamudString().TextValue,
                StartTime  = start,
                SpotDay    = day,
                SpotSunset = sunset,
                SpotNight  = night,
                Area       = i switch
                {
                    < 13 => OceanArea.Aldenard,
                    < 22 => OceanArea.Othard,
                    _ => OceanArea.Unknown,
                },
            };
```