### PR TITLE
Fix context menu entries showing everywhere

### DIFF
--- a/GatherBuddy/Plugin/ContextMenu.cs
+++ b/GatherBuddy/Plugin/ContextMenu.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Dalamud.Game.Gui.ContextMenu;
 using Dalamud.Plugin.Services;
-using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using GatherBuddy.Interfaces;
 
@@ -115,6 +114,12 @@ public class ContextMenu : IDisposable
     private unsafe IGatherable? HandleSatisfactionSupply()
     {
         var agent = AgentSatisfactionSupply.Instance();
+        if (!agent->IsAgentActive())
+            return null;
+
+        var agentContext = AgentContext.Instance();
+        if (agentContext->CurrentContextMenuTarget != null)
+            return null;
 
         var itemIdx = agent->NpcInfo.SelectedItemIndex;
         if (itemIdx < 0 || itemIdx >= agent->Items.Length)


### PR DESCRIPTION
This happens when you opened the context menu for an item in the Custom Deliveries via /timers once, since it defaults to HandleSatisfactionSupply when there is no AddonName in the args.

Sadly this whole context menu system sucks a bit, so I just added some checks to make it work.